### PR TITLE
Refine shipment page layout to prevent overflow

### DIFF
--- a/lib/pages/shipment.dart
+++ b/lib/pages/shipment.dart
@@ -18,158 +18,266 @@ class _ShipmentPageState extends State<ShipmentPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Container(
-          color: bg,
-          height: 170,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Padding(
-                padding: EdgeInsets.fromLTRB(15, 45, 0, 25),
-                child: Text(
-                  'ประวัติการจัดส่ง',
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                    shadows: [
-                      Shadow(
-                        offset: Offset(1.5, 1.5),
-                        blurRadius: 2.0,
-                        color: green,
-                      ),
-                    ],
-                  ),
+    return SafeArea(
+      bottom: false,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _Header(
+            tabs: tabs,
+            selectedIndex: _selectedIndex,
+            onTabSelected: (index) => setState(() => _selectedIndex = index),
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+              children: const [
+                _ShipmentCard(
+                  sender: 'ผู้ส่ง',
+                  receiver: 'ผู้รับ',
+                  status: 'ไรเดอร์กำลังเดินทางไปรับสินค้า',
                 ),
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: List.generate(tabs.length, (index) {
-                  final isActive = _selectedIndex == index;
-                  return Column(
-                    children: [
-                      FilledButton(
-                        onPressed: () {
-                          setState(() => _selectedIndex = index);
-                        },
-                        style: FilledButton.styleFrom(
-                          backgroundColor: green.withOpacity(0.08),
-                          foregroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 12,
-                          ),
-                          shape: const StadiumBorder(),
-                        ),
-                        child: Text(
-                          tabs[index],
-                          style: const TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      AnimatedContainer(
-                        duration: const Duration(milliseconds: 250),
-                        height: 3,
-                        width: isActive ? 100 : 0,
-                        decoration: BoxDecoration(
-                          color: isActive ? green : Colors.transparent,
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                    ],
-                  );
-                }),
-              ),
-            ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.tabs,
+    required this.selectedIndex,
+    required this.onTabSelected,
+  });
+
+  final List<String> tabs;
+  final int selectedIndex;
+  final ValueChanged<int> onTabSelected;
+
+  static const EdgeInsets _headerPadding = EdgeInsets.only(
+    top: 32,
+    left: 20,
+    right: 20,
+    bottom: 20,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: const BoxDecoration(
+        color: _ShipmentPageState.bg,
+        borderRadius: BorderRadius.only(
+          bottomLeft: Radius.circular(24),
+          bottomRight: Radius.circular(24),
+        ),
+      ),
+      padding: _headerPadding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'ประวัติการจัดส่ง',
+            style: TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+              shadows: [
+                Shadow(
+                  offset: Offset(1.5, 1.5),
+                  blurRadius: 2.0,
+                  color: _ShipmentPageState.green,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                for (var i = 0; i < tabs.length; i++)
+                  Padding(
+                    padding: EdgeInsets.only(right: i == tabs.length - 1 ? 0 : 12),
+                    child: _TabChip(
+                      label: tabs[i],
+                      active: selectedIndex == i,
+                      onTap: () => onTabSelected(i),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TabChip extends StatelessWidget {
+  const _TabChip({
+    required this.label,
+    required this.active,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool active;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        FilledButton(
+          onPressed: onTap,
+          style: FilledButton.styleFrom(
+            backgroundColor:
+                active ? _ShipmentPageState.green.withOpacity(0.16) : _ShipmentPageState.green.withOpacity(0.08),
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+            shape: const StadiumBorder(),
+          ),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.all(10.0),
-          child: Container(
-            height: 120,
-            decoration: BoxDecoration(
-              color: const Color(0xFFD9D9D9).withOpacity(0.05),
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                color: const Color(0xFF16A34A).withOpacity(0.3),
-                width: 1,
-              ),
-            ),
-            padding: const EdgeInsets.all(10),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Icon(
-                      BootstrapIcons.box,
-                      color: Colors.white,
-                      size: 30,
-                    ),
-                    const SizedBox(width: 12),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: const [
-                        Text(
-                          'ผู้ส่ง',
-                          style: TextStyle(
-                            fontSize: 16,
-                            color: Colors.white,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                        Text(
-                          'ผู้รับ',
-                          style: TextStyle(
-                            fontSize: 16,
-                            color: Colors.white,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                        SizedBox(height: 4),
-                        Text(
-                          'ไรเดอร์กำลังเดินทางไปรับสินค้า',
-                          style: TextStyle(
-                            fontSize: 15,
-                            color: Color(0xFF16A34A),
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
+        const SizedBox(height: 6),
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          height: 3,
+          width: active ? 70 : 0,
+          decoration: BoxDecoration(
+            color: active ? _ShipmentPageState.green : Colors.transparent,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
-                FilledButton(
-                  onPressed: () {},
-                  style: FilledButton.styleFrom(
-                    backgroundColor: const Color(0xFF16A34A),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 10,
-                    ),
-                    shape: const StadiumBorder(),
-                  ),
-                  child: const Text(
-                    'รายละเอียด',
-                    style: TextStyle(
-                      fontSize: 16,
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
+class _ShipmentCard extends StatelessWidget {
+  const _ShipmentCard({
+    required this.sender,
+    required this.receiver,
+    required this.status,
+  });
+
+  final String sender;
+  final String receiver;
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFFD9D9D9).withOpacity(0.05),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: const Color(0xFF16A34A).withOpacity(0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            BootstrapIcons.box,
+            color: Colors.white,
+            size: 32,
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _InfoRow(
+                  label: 'ผู้ส่ง',
+                  value: sender,
+                ),
+                const SizedBox(height: 6),
+                _InfoRow(
+                  label: 'ผู้รับ',
+                  value: receiver,
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  status,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    color: _ShipmentPageState.green,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
               ],
             ),
+          ),
+          const SizedBox(width: 12),
+          FilledButton(
+            onPressed: () {},
+            style: FilledButton.styleFrom(
+              backgroundColor: _ShipmentPageState.green,
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+              shape: const StadiumBorder(),
+            ),
+            child: const Text(
+              'รายละเอียด',
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '$label : ',
+          style: const TextStyle(
+            fontSize: 15,
+            color: Colors.white70,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(
+              fontSize: 15,
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
- restructure the shipment header with a safe area wrapper and scrollable tab chips
- split the layout into reusable widgets that improve spacing and readability
- wrap shipment content in a list view so the page no longer overflows on smaller screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f41eb33b0883298fec58bed9c2e32c