### PR TITLE
Add Firestore-backed profile editing screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:delivery_app/models/user.dart';
 import 'package:delivery_app/pages/addNewAddress.dart';
+import 'package:delivery_app/pages/editProfile.dart';
 import 'package:delivery_app/pages/index.dart';
 import 'package:delivery_app/pages/login.dart';
 import 'package:delivery_app/pages/pickAddressMap.dart';
@@ -74,6 +75,17 @@ class MyApp extends StatelessWidget {
             return buildTransitionPage(
               key: state.pageKey,
               child: ProfilePage(uid: uid, profile: profile),
+            );
+          },
+        ),
+        GoRoute(
+          path: '/profile/edit',
+          name: 'editProfile',
+          pageBuilder: (context, state) {
+            final profile = state.extra as Users;
+            return buildTransitionPage(
+              key: state.pageKey,
+              child: EditProfilePage(profile: profile),
             );
           },
         ),

--- a/lib/pages/editProfile.dart
+++ b/lib/pages/editProfile.dart
@@ -1,0 +1,392 @@
+import 'dart:typed_data';
+
+import 'package:bootstrap_icons/bootstrap_icons.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:delivery_app/models/user.dart';
+import 'package:delivery_app/services/upload_img.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+
+class EditProfilePage extends StatefulWidget {
+  const EditProfilePage({super.key, required this.profile});
+
+  final Users profile;
+
+  @override
+  State<EditProfilePage> createState() => _EditProfilePageState();
+}
+
+class _EditProfilePageState extends State<EditProfilePage> {
+  static const Color _background = Color(0xFF111827);
+  static const Color _cardBackground = Color(0xFF16A34A);
+  static const Color _buttonGreen = Color(0xFF16A34A);
+
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _usernameController;
+  late final TextEditingController _phoneController;
+
+  XFile? _pickedImage;
+  Uint8List? _avatarPreviewBytes;
+  String? _currentAvatarUrl;
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _usernameController = TextEditingController(text: widget.profile.username);
+    _phoneController = TextEditingController(text: widget.profile.phone ?? '');
+    _currentAvatarUrl = widget.profile.avatar;
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+
+    try {
+      final image = await picker.pickImage(
+        source: ImageSource.gallery,
+        imageQuality: 85,
+      );
+
+      if (image == null) return;
+
+      final bytes = await image.readAsBytes();
+      setState(() {
+        _pickedImage = image;
+        _avatarPreviewBytes = bytes;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('ไม่สามารถเลือกรูปภาพได้: $e')),
+      );
+    }
+  }
+
+  Future<void> _submit() async {
+    if (_isSubmitting) return;
+    if (!_formKey.currentState!.validate()) return;
+
+    FocusScope.of(context).unfocus();
+
+    setState(() => _isSubmitting = true);
+
+    try {
+      String? avatarUrl = _currentAvatarUrl;
+
+      if (_pickedImage != null) {
+        final uploadResult = await UploadImgService.uploadXFile(
+          xfile: _pickedImage!,
+          folder: 'users/avatars',
+        );
+        avatarUrl = uploadResult.secureUrl ?? uploadResult.url ?? avatarUrl;
+      }
+
+      final payload = <String, dynamic>{
+        'username': _usernameController.text.trim(),
+        'phone': _phoneController.text.trim(),
+        'avatar': avatarUrl,
+      };
+
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(widget.profile.uid)
+          .update(payload);
+
+      if (!mounted) return;
+
+      final updatedUser = Users(
+        uid: widget.profile.uid,
+        role: widget.profile.role,
+        email: widget.profile.email,
+        username: payload['username'] as String,
+        displayName: widget.profile.displayName,
+        avatar: avatarUrl,
+        phone: payload['phone'] as String,
+        createdAt: widget.profile.createdAt,
+      );
+
+      context.pop(updatedUser);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('เกิดข้อผิดพลาดในการบันทึกข้อมูล: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _background,
+      body: Stack(
+        children: [
+          Container(
+            height: 220,
+            decoration: const BoxDecoration(
+              color: Color(0xFF0B0F19),
+              borderRadius: BorderRadius.only(
+                bottomLeft: Radius.circular(30),
+                bottomRight: Radius.circular(30),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      IconButton(
+                        onPressed: () => context.pop(),
+                        icon: const Icon(
+                          BootstrapIcons.chevron_left,
+                          color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      const Text(
+                        'แก้ไขโปรไฟล์',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 30),
+                  Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Container(
+                        width: double.infinity,
+                        margin: const EdgeInsets.only(top: 70),
+                        padding: const EdgeInsets.fromLTRB(20, 90, 20, 24),
+                        decoration: BoxDecoration(
+                          color: _cardBackground.withOpacity(0.08),
+                          borderRadius: BorderRadius.circular(35),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.25),
+                              blurRadius: 4,
+                              offset: const Offset(0, 4),
+                            ),
+                          ],
+                        ),
+                        child: Form(
+                          key: _formKey,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              _buildLabel('หมายเลขโทรศัพท์'),
+                              const SizedBox(height: 8),
+                              _buildTextField(
+                                controller: _phoneController,
+                                hintText: 'กรอกหมายเลขโทรศัพท์',
+                                icon: BootstrapIcons.telephone,
+                                keyboardType: TextInputType.phone,
+                                validator: (value) {
+                                  final trimmed = value?.trim() ?? '';
+                                  if (trimmed.isEmpty) {
+                                    return 'กรุณากรอกหมายเลขโทรศัพท์';
+                                  }
+                                  if (trimmed.length < 9) {
+                                    return 'หมายเลขโทรศัพท์ไม่ถูกต้อง';
+                                  }
+                                  return null;
+                                },
+                              ),
+                              const SizedBox(height: 18),
+                              _buildLabel('ชื่อผู้ใช้'),
+                              const SizedBox(height: 8),
+                              _buildTextField(
+                                controller: _usernameController,
+                                hintText: 'กรอกชื่อผู้ใช้',
+                                icon: BootstrapIcons.person,
+                                validator: (value) {
+                                  final trimmed = value?.trim() ?? '';
+                                  if (trimmed.isEmpty) {
+                                    return 'กรุณากรอกชื่อผู้ใช้';
+                                  }
+                                  if (trimmed.length < 3) {
+                                    return 'ชื่อผู้ใช้ต้องมีอย่างน้อย 3 ตัวอักษร';
+                                  }
+                                  return null;
+                                },
+                              ),
+                              const SizedBox(height: 24),
+                              SizedBox(
+                                width: double.infinity,
+                                child: FilledButton(
+                                  onPressed: _isSubmitting ? null : _submit,
+                                  style: FilledButton.styleFrom(
+                                    backgroundColor: _buttonGreen,
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(14),
+                                    ),
+                                    padding:
+                                        const EdgeInsets.symmetric(vertical: 14),
+                                  ),
+                                  child: _isSubmitting
+                                      ? const SizedBox(
+                                          width: 20,
+                                          height: 20,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2.5,
+                                            valueColor: AlwaysStoppedAnimation(
+                                              Colors.white,
+                                            ),
+                                          ),
+                                        )
+                                      : const Text(
+                                          'บันทึกการเปลี่ยนแปลง',
+                                          style: TextStyle(
+                                            color: Colors.white,
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                ),
+                              ),
+                              const SizedBox(height: 14),
+                              SizedBox(
+                                width: double.infinity,
+                                child: OutlinedButton(
+                                  onPressed: _isSubmitting
+                                      ? null
+                                      : () => context.pop(),
+                                  style: OutlinedButton.styleFrom(
+                                    foregroundColor: Colors.white,
+                                    side: const BorderSide(color: Colors.white54),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(14),
+                                    ),
+                                    padding:
+                                        const EdgeInsets.symmetric(vertical: 14),
+                                  ),
+                                  child: const Text(
+                                    'ย้อนกลับ',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child: GestureDetector(
+                            onTap: _isSubmitting ? null : _pickImage,
+                            child: Stack(
+                              alignment: Alignment.bottomRight,
+                              children: [
+                                CircleAvatar(
+                                  radius: 65,
+                                  backgroundColor: const Color(0xFF0B0F19),
+                                  child: CircleAvatar(
+                                    radius: 60,
+                                    backgroundColor: Colors.white,
+                                    backgroundImage: _buildAvatarImage(),
+                                  ),
+                                ),
+                                Positioned(
+                                  bottom: 6,
+                                  right: 6,
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      color: _buttonGreen,
+                                      borderRadius: BorderRadius.circular(18),
+                                    ),
+                                    padding: const EdgeInsets.all(6),
+                                    child: const Icon(
+                                      BootstrapIcons.pencil,
+                                      color: Colors.white,
+                                      size: 16,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  ImageProvider? _buildAvatarImage() {
+    if (_avatarPreviewBytes != null) {
+      return MemoryImage(_avatarPreviewBytes!);
+    }
+    if (_currentAvatarUrl != null && _currentAvatarUrl!.isNotEmpty) {
+      return NetworkImage(_currentAvatarUrl!);
+    }
+    return const AssetImage('assets/images/profile_placeholder.png');
+  }
+
+  Widget _buildLabel(String text) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  Widget _buildTextField({
+    required TextEditingController controller,
+    required String hintText,
+    required IconData icon,
+    TextInputType? keyboardType,
+    String? Function(String?)? validator,
+  }) {
+    return TextFormField(
+      controller: controller,
+      keyboardType: keyboardType,
+      validator: validator,
+      style: const TextStyle(color: Colors.black87, fontSize: 16),
+      decoration: InputDecoration(
+        filled: true,
+        fillColor: Colors.white,
+        hintText: hintText,
+        hintStyle: TextStyle(color: Colors.grey.shade500),
+        prefixIcon: Icon(icon, color: _buttonGreen),
+        contentPadding: const EdgeInsets.symmetric(vertical: 16),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide.none,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -13,6 +13,22 @@ class ProfilePage extends StatefulWidget {
 
 class _ProfilePageState extends State<ProfilePage> {
   static const Color green = Color(0xFF16A34A);
+  late Users _profile;
+
+  @override
+  void initState() {
+    super.initState();
+    _profile = widget.profile;
+  }
+
+  @override
+  void didUpdateWidget(covariant ProfilePage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.profile != oldWidget.profile) {
+      _profile = widget.profile;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -49,7 +65,7 @@ class _ProfilePageState extends State<ProfilePage> {
               child: Column(
                 children: [
                   Text(
-                    widget.profile.username,
+                    _profile.username,
                     style: const TextStyle(
                       color: Colors.white,
                       fontSize: 20,
@@ -58,7 +74,7 @@ class _ProfilePageState extends State<ProfilePage> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    widget.profile.phone!,
+                    _profile.phone ?? '-',
                     style: const TextStyle(color: Colors.white70, fontSize: 16),
                   ),
                   const SizedBox(height: 25),
@@ -66,8 +82,22 @@ class _ProfilePageState extends State<ProfilePage> {
                   _buildMenu(
                     Icons.person_outline,
                     'แก้ไขข้อมูลส่วนตัว',
-                    onTap: () {
-                      print('แก้ไขข้อมูลส่วนตัว');
+                    onTap: () async {
+                      final updated = await context.pushNamed(
+                        'editProfile',
+                        queryParameters: {'uid': widget.uid},
+                        extra: _profile,
+                      );
+
+                      if (!mounted) return;
+                      if (updated is Users) {
+                        setState(() => _profile = updated);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('อัปเดตข้อมูลส่วนตัวเรียบร้อยแล้ว'),
+                          ),
+                        );
+                      }
                     },
                   ),
                   _buildMenu(
@@ -129,7 +159,7 @@ class _ProfilePageState extends State<ProfilePage> {
                 child: CircleAvatar(
                   radius: 60,
                   backgroundColor: Colors.white,
-                  backgroundImage: NetworkImage(widget.profile.avatar!),
+                  backgroundImage: _buildAvatarImage(),
                 ),
               ),
             ),
@@ -179,5 +209,13 @@ class _ProfilePageState extends State<ProfilePage> {
         ),
       ),
     );
+  }
+
+  ImageProvider _buildAvatarImage() {
+    final avatar = _profile.avatar;
+    if (avatar != null && avatar.isNotEmpty) {
+      return NetworkImage(avatar);
+    }
+    return const AssetImage('assets/images/profile_placeholder.png');
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated edit profile page with form validation, avatar picker, and Firestore persistence
- wire the edit screen into the GoRouter configuration and profile menu navigation
- refresh the profile view with updated user data and placeholder avatar support

## Testing
- ⚠️ `flutter analyze` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f422aaa03c83298473c996c758b0c4