### PR TITLE
Convert dialogs to awesome snackbar notifications

### DIFF
--- a/lib/components/custom_dialog.dart
+++ b/lib/components/custom_dialog.dart
@@ -1,203 +1,103 @@
+import 'package:awesome_snackbar_content/awesome_snackbar_content.dart';
 import 'package:flutter/material.dart';
 
-Future<void> showSuccessDialog(BuildContext context, {VoidCallback? onOk}) {
-  return showDialog(
-    context: context,
-    barrierDismissible: false,
-    builder: (_) => Dialog(
-      insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(24, 22, 24, 18),
-        decoration: BoxDecoration(
-          color: const Color(0xFF0B0F19), // เทาอ่อนแบบในภาพ
-          borderRadius: BorderRadius.circular(24),
-          boxShadow: const [
-            BoxShadow(
-              color: Colors.black26,
-              blurRadius: 18,
-              offset: Offset(0, 10),
-            ),
-          ],
-        ),
-        child: Stack(
-          children: [
-            // เนื้อหา
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: const [
-                Text(
-                  "สำเร็จ",
-                  style: const TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                    shadows: [
-                      Shadow(
-                        offset: Offset(1.5, 1.5),
-                        blurRadius: 2.0,
-                        color: Color(0xFF16A34A),
-                      ),
-                    ],
-                  ),
-                ),
-                SizedBox(height: 10),
-                // "สมัครบัญชีสำเร็จ"
-                Text(
-                  "สมัครบัญชีสำเร็จ",
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                SizedBox(height: 56), // เผื่อที่ว่างสำหรับปุ่มด้านล่างขวา
-              ],
-            ),
+ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showAwesomeSnackBar(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required ContentType contentType,
+  Duration duration = const Duration(seconds: 4),
+}) {
+  final messenger = ScaffoldMessenger.of(context);
+  messenger.hideCurrentSnackBar();
 
-            // ปุ่ม "ตกลง" ล่างขวา พร้อมเงาเรือง
-            Positioned(
-              right: 0,
-              bottom: 0,
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.of(context).pop();
-                  onOk?.call();
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 18,
-                    vertical: 10,
-                  ),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF16A34A),
-                    borderRadius: BorderRadius.circular(999),
-                    boxShadow: const [
-                      BoxShadow(
-                        color: Color(0x6616A34A), // เขียวจาง ๆ ให้เป็นเงาเรือง
-                        blurRadius: 14,
-                        offset: Offset(0, 6),
-                      ),
-                    ],
-                  ),
-                  child: const Text(
-                    "ตกลง",
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w900,
-                      fontSize: 16,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
+  final snackBar = SnackBar(
+    elevation: 0,
+    behavior: SnackBarBehavior.floating,
+    backgroundColor: Colors.transparent,
+    duration: duration,
+    content: AwesomeSnackbarContent(
+      title: title,
+      message: message,
+      contentType: contentType,
     ),
   );
+
+  return messenger.showSnackBar(snackBar);
+}
+
+Future<void> showSuccessDialog(
+  BuildContext context, {
+  String title = "สำเร็จ",
+  String message = "ดำเนินการสำเร็จ",
+  Duration duration = const Duration(seconds: 4),
+  VoidCallback? onOk,
+}) async {
+  final controller = showAwesomeSnackBar(
+    context,
+    title: title,
+    message: message,
+    contentType: ContentType.success,
+    duration: duration,
+  );
+
+  await controller.closed;
+  onOk?.call();
 }
 
 Future<void> showErrorDialog(
   BuildContext context, {
   String title = "ไม่สำเร็จ",
   String message = "ดำเนินการไม่สำเร็จ",
-  String actionLabel = "ตกลง",
+  Duration duration = const Duration(seconds: 4),
   VoidCallback? onAction,
-}) {
-  return showDialog(
-    context: context,
-    barrierDismissible: false,
-    builder: (_) => Dialog(
-      insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(24, 22, 24, 18),
-        decoration: BoxDecoration(
-          // ถ้าต้องการเทา D9D9D9 @ 5% ใช้ 0x0DD9D9D9 แทน
-          color: const Color(0xFF0B0F19),
-          borderRadius: BorderRadius.circular(24),
-          boxShadow: const [
-            BoxShadow(
-              color: Colors.black26,
-              blurRadius: 18,
-              offset: Offset(0, 10),
-            ),
-          ],
-        ),
-        child: Stack(
-          children: [
-            // เนื้อหา
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  title,
-                  style: const TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                    shadows: [
-                      Shadow(
-                        offset: Offset(1.5, 1.5),
-                        blurRadius: 2.0,
-                        color: Color(0xFFDC2626), // แดงเรือง
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  message,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 56),
-              ],
-            ),
-
-            // ปุ่มล่างขวา (โทนแดง)
-            Positioned(
-              right: 0,
-              bottom: 0,
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.of(context).pop();
-                  onAction?.call();
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 18,
-                    vertical: 10,
-                  ),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFDC2626), // red-600
-                    borderRadius: BorderRadius.circular(999),
-                    boxShadow: const [
-                      BoxShadow(
-                        color: Color(0x66DC2626), // เงาแดงเรือง
-                        blurRadius: 14,
-                        offset: Offset(0, 6),
-                      ),
-                    ],
-                  ),
-                  child: Text(
-                    actionLabel,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w900,
-                      fontSize: 16,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    ),
+}) async {
+  final controller = showAwesomeSnackBar(
+    context,
+    title: title,
+    message: message,
+    contentType: ContentType.failure,
+    duration: duration,
   );
+
+  await controller.closed;
+  onAction?.call();
+}
+
+Future<void> showWarningSnackBar(
+  BuildContext context, {
+  required String title,
+  required String message,
+  Duration duration = const Duration(seconds: 4),
+  VoidCallback? onClosed,
+}) async {
+  final controller = showAwesomeSnackBar(
+    context,
+    title: title,
+    message: message,
+    contentType: ContentType.warning,
+    duration: duration,
+  );
+
+  await controller.closed;
+  onClosed?.call();
+}
+
+Future<void> showInfoSnackBar(
+  BuildContext context, {
+  required String title,
+  required String message,
+  Duration duration = const Duration(seconds: 4),
+  VoidCallback? onClosed,
+}) async {
+  final controller = showAwesomeSnackBar(
+    context,
+    title: title,
+    message: message,
+    contentType: ContentType.help,
+    duration: duration,
+  );
+
+  await controller.closed;
+  onClosed?.call();
 }

--- a/lib/pages/addDelivery.dart
+++ b/lib/pages/addDelivery.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:bootstrap_icons/bootstrap_icons.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:delivery_app/components/custom_TextField.dart';
+import 'package:delivery_app/components/custom_dialog.dart';
 import 'package:delivery_app/services/upload_img.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
@@ -390,15 +391,19 @@ class _AddDeliveryPageState extends State<AddDeliveryPage> {
 
   void addDeliveryItem() async {
     if (deliNameCtrl.text.trim().isEmpty) {
-      ScaffoldMessenger.of(
+      await showWarningSnackBar(
         context,
-      ).showSnackBar(const SnackBar(content: Text("กรุณากรอกชื่อสินค้า")));
+        title: "ข้อมูลไม่ครบ",
+        message: "กรุณากรอกชื่อสินค้า",
+      );
       return;
     }
     if (_selectedReceiver == null) {
-      ScaffoldMessenger.of(
+      await showWarningSnackBar(
         context,
-      ).showSnackBar(const SnackBar(content: Text("กรุณาเลือกผู้รับสินค้า")));
+        title: "ข้อมูลไม่ครบ",
+        message: "กรุณาเลือกผู้รับสินค้า",
+      );
       return;
     }
 
@@ -440,14 +445,17 @@ class _AddDeliveryPageState extends State<AddDeliveryPage> {
       await docRef.set(data);
 
       if (!mounted) return;
-      ScaffoldMessenger.of(
+      await showSuccessDialog(
         context,
-      ).showSnackBar(const SnackBar(content: Text("สร้างรายการจัดส่งสำเร็จ!")));
+        message: "สร้างรายการจัดส่งสำเร็จ!",
+      );
       context.pop();
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("เกิดข้อผิดพลาด: ${e.toString()}")),
+      await showErrorDialog(
+        context,
+        title: "เกิดข้อผิดพลาด",
+        message: "เกิดข้อผิดพลาด: ${e.toString()}",
       );
     } finally {
       if (mounted) {
@@ -521,9 +529,11 @@ class _ReceiverPickerSheetState extends State<ReceiverPickerSheet> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(
+        await showErrorDialog(
           context,
-        ).showSnackBar(SnackBar(content: Text("เกิดข้อผิดพลาดในการค้นหา: $e")));
+          title: "เกิดข้อผิดพลาด",
+          message: "เกิดข้อผิดพลาดในการค้นหา: $e",
+        );
       }
     } finally {
       if (mounted) {

--- a/lib/pages/addNewAddress.dart
+++ b/lib/pages/addNewAddress.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-import 'package:awesome_snackbar_content/awesome_snackbar_content.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:delivery_app/components/custom_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
@@ -172,22 +171,13 @@ class _AddNewAddressState extends State<AddNewAddress> {
     };
     await docRef.set(newAddress);
 
-    final snackBar = SnackBar(
-      elevation: 0,
-      behavior: SnackBarBehavior.floating,
-      backgroundColor: Colors.transparent,
-      content: AwesomeSnackbarContent(
-        title: 'สำเร็จ!',
-        message: 'บันทึกที่อยู่เรียบร้อยแล้ว 🎉',
-        contentType: ContentType.success,
-      ),
-    );
+    if (!mounted) return;
 
-    if (context.mounted) {
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(snackBar);
-    }
+    await showSuccessDialog(
+      context,
+      title: 'สำเร็จ!',
+      message: 'บันทึกที่อยู่เรียบร้อยแล้ว 🎉',
+    );
   }
 }
 

--- a/lib/pages/editProfile.dart
+++ b/lib/pages/editProfile.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:bootstrap_icons/bootstrap_icons.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:delivery_app/components/custom_dialog.dart';
 import 'package:delivery_app/models/user.dart';
 import 'package:delivery_app/services/upload_img.dart';
 import 'package:flutter/material.dart';
@@ -64,8 +65,10 @@ class _EditProfilePageState extends State<EditProfilePage> {
       });
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('ไม่สามารถเลือกรูปภาพได้: $e')),
+      await showWarningSnackBar(
+        context,
+        title: 'ไม่สามารถเลือกรูปภาพได้',
+        message: '$e',
       );
     }
   }
@@ -116,8 +119,10 @@ class _EditProfilePageState extends State<EditProfilePage> {
       context.pop(updatedUser);
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('เกิดข้อผิดพลาดในการบันทึกข้อมูล: $e')),
+      await showErrorDialog(
+        context,
+        title: 'เกิดข้อผิดพลาด',
+        message: 'เกิดข้อผิดพลาดในการบันทึกข้อมูล: $e',
       );
     } finally {
       if (mounted) {

--- a/lib/pages/login.dart
+++ b/lib/pages/login.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:delivery_app/components/custom_dialog.dart';
 import 'package:delivery_app/models/user.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -33,9 +34,11 @@ class _LoginPageState extends State<LoginPage> {
     final inputPass = passwordController.text.trim();
 
     if (inputUser.isEmpty || inputPass.isEmpty) {
-      ScaffoldMessenger.of(
+      await showWarningSnackBar(
         context,
-      ).showSnackBar(const SnackBar(content: Text('กรุณากรอกข้อมูลให้ครบ')));
+        title: 'ข้อมูลไม่ครบ',
+        message: 'กรุณากรอกข้อมูลให้ครบ',
+      );
       return;
     }
 
@@ -89,23 +92,29 @@ class _LoginPageState extends State<LoginPage> {
           .get();
       final profile = profDoc.data();
 
-      ScaffoldMessenger.of(
+      await showSuccessDialog(
         context,
-      ).showSnackBar(SnackBar(content: Text('เข้าสู่ระบบ $role สำเร็จ ')));
+        message: 'เข้าสู่ระบบ $role สำเร็จ',
+      );
 
+      if (!mounted) return;
       context.goNamed(
         'index',
         queryParameters: {'uid': UserID},
         extra: Users.fromMap(profile!),
       );
     } on FirebaseAuthException catch (e) {
-      ScaffoldMessenger.of(
+      await showErrorDialog(
         context,
-      ).showSnackBar(SnackBar(content: Text('Auth Error: ${e.message}')));
+        title: 'เข้าสู่ระบบไม่สำเร็จ',
+        message: 'Auth Error: ${e.message}',
+      );
     } catch (e) {
-      ScaffoldMessenger.of(
+      await showErrorDialog(
         context,
-      ).showSnackBar(SnackBar(content: Text('เกิดข้อผิดพลาด: $e')));
+        title: 'เกิดข้อผิดพลาด',
+        message: 'เกิดข้อผิดพลาด: $e',
+      );
     }
   }
 
@@ -411,11 +420,11 @@ class _LoginPageState extends State<LoginPage> {
                                 ],
                               ),
                               GestureDetector(
-                                onTap: () {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(
-                                      content: Text("ไปหน้าลืมรหัสผ่าน"),
-                                    ),
+                                onTap: () async {
+                                  await showInfoSnackBar(
+                                    context,
+                                    title: 'ลืมรหัสผ่าน',
+                                    message: 'ไปหน้าลืมรหัสผ่าน',
                                   );
                                 },
                                 child: const Text(

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -1,3 +1,4 @@
+import 'package:delivery_app/components/custom_dialog.dart';
 import 'package:delivery_app/models/user.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -92,10 +93,9 @@ class _ProfilePageState extends State<ProfilePage> {
                       if (!mounted) return;
                       if (updated is Users) {
                         setState(() => _profile = updated);
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(
-                            content: Text('อัปเดตข้อมูลส่วนตัวเรียบร้อยแล้ว'),
-                          ),
+                        await showSuccessDialog(
+                          context,
+                          message: 'อัปเดตข้อมูลส่วนตัวเรียบร้อยแล้ว',
                         );
                       }
                     },

--- a/lib/pages/register.dart
+++ b/lib/pages/register.dart
@@ -90,9 +90,11 @@ class _RegisterPageState extends State<RegisterPage> {
     if (submitting) return;
     try {
       if (passCtrl.text != confirmCtrl.text) {
-        ScaffoldMessenger.of(
+        await showErrorDialog(
           context,
-        ).showSnackBar(const SnackBar(content: Text("รหัสผ่านไม่ตรงกัน")));
+          title: "รหัสผ่านไม่ตรงกัน",
+          message: "กรุณากรอกยืนยันรหัสผ่านให้ตรงกับรหัสผ่าน",
+        );
         return;
       }
 
@@ -157,13 +159,11 @@ class _RegisterPageState extends State<RegisterPage> {
 
       if (!mounted) return;
 
-      // ✅ แจ้งผลสำเร็จ (SnackBar หรือ Dialog อย่างใดอย่างหนึ่ง)
-      ScaffoldMessenger.of(
+      // ✅ แจ้งผลสำเร็จด้วย Awesome Snackbar
+      await showSuccessDialog(
         context,
-      ).showSnackBar(const SnackBar(content: Text("สมัครบัญชีสำเร็จ")));
-
-      // หรือใช้ Dialog สวย ๆ
-      await showSuccessDialog(context);
+        message: "สมัครบัญชีสำเร็จ",
+      );
 
       context.go("/"); // กลับหน้า Login
     } on FirebaseAuthException catch (e) {
@@ -172,15 +172,20 @@ class _RegisterPageState extends State<RegisterPage> {
       if (e.toString().contains('by another account.')) {
         errMes = 'อีเมลนี้ถูกใช้งานแล้ว โปรดลองใหม่';
       }
-      showErrorDialog(context, title: "สมัครไม่สำเร็จ", message: errMes);
-      ScaffoldMessenger.of(
+      await showErrorDialog(
         context,
-      ).showSnackBar(SnackBar(content: Text("เกิดข้อผิดพลาด: ${e.message}")));
+        title: "สมัครไม่สำเร็จ",
+        message: errMes.isNotEmpty
+            ? errMes
+            : 'เกิดข้อผิดพลาด: ${e.message ?? 'ไม่ทราบสาเหตุ'}',
+      );
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
+      await showErrorDialog(
         context,
-      ).showSnackBar(SnackBar(content: Text("เกิดข้อผิดพลาด: $e")));
+        title: "เกิดข้อผิดพลาด",
+        message: "เกิดข้อผิดพลาด: $e",
+      );
     } finally {
       if (mounted) setState(() => submitting = false); // ⬅️ หยุดโหลด
     }

--- a/lib/pages/register_rider.dart
+++ b/lib/pages/register_rider.dart
@@ -423,6 +423,7 @@ class _RegisterRiderPageState extends State<RegisterRiderPage> {
 
       await showSuccessDialog(
         context,
+        message: "สมัครบัญชีสำเร็จ",
         onOk: () => context.go("/"), // กลับหน้า Login
       );
     } on FirebaseAuthException catch (e) {


### PR DESCRIPTION
## Summary
- replace the custom dialog widgets with helpers built on awesome_snackbar_content
- update registration, login, and profile flows to show success and error snackbars with appropriate content types
- swap remaining SnackBar usages to the shared snackbar utilities across delivery and address pages

## Testing
- Not run (Flutter SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f425ce15b88329b58972a15b7e560f