### PR TITLE
Implement Firestore-backed address management

### DIFF
--- a/lib/models/address.dart
+++ b/lib/models/address.dart
@@ -1,0 +1,59 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Address {
+  Address({
+    required this.id,
+    required this.uid,
+    required this.label,
+    required this.fullAddress,
+    required this.isDefault,
+    this.lat,
+    this.lng,
+    this.createdAt,
+    this.updatedAt,
+    this.extra,
+  });
+
+  final String id;
+  final String uid;
+  final String label;
+  final String fullAddress;
+  final int isDefault;
+  final double? lat;
+  final double? lng;
+  final Timestamp? createdAt;
+  final Timestamp? updatedAt;
+  final Map<String, dynamic>? extra;
+
+  factory Address.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final data = doc.data() ?? <String, dynamic>{};
+    return Address(
+      id: data['addr_id'] as String? ?? doc.id,
+      uid: data['uid'] as String? ?? '',
+      label: data['label'] as String? ?? data['addressName'] as String? ?? '-',
+      fullAddress: data['fullAddress'] as String? ?? '-',
+      isDefault: (data['is_default'] as num?)?.toInt() ?? 1,
+      lat: (data['lat'] as num?)?.toDouble(),
+      lng: (data['lng'] as num?)?.toDouble(),
+      createdAt: data['create_at'] as Timestamp?,
+      updatedAt: data['update_at'] as Timestamp?,
+      extra: data,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'addr_id': id,
+      'uid': uid,
+      'label': label,
+      'fullAddress': fullAddress,
+      'lat': lat,
+      'lng': lng,
+      'is_default': isDefault,
+      'create_at': createdAt,
+      'update_at': updatedAt,
+    };
+  }
+}

--- a/lib/models/thai_address.dart
+++ b/lib/models/thai_address.dart
@@ -1,0 +1,68 @@
+class Province {
+  Province({
+    required this.id,
+    required this.nameTh,
+    required this.nameEn,
+  });
+
+  final int id;
+  final String nameTh;
+  final String nameEn;
+
+  factory Province.fromJson(Map<String, dynamic> json) {
+    return Province(
+      id: (json['id'] as num).toInt(),
+      nameTh: json['name_th'] as String,
+      nameEn: json['name_en'] as String,
+    );
+  }
+}
+
+class District {
+  District({
+    required this.id,
+    required this.nameTh,
+    required this.nameEn,
+    required this.provinceId,
+  });
+
+  final int id;
+  final String nameTh;
+  final String nameEn;
+  final int provinceId;
+
+  factory District.fromJson(Map<String, dynamic> json) {
+    return District(
+      id: (json['id'] as num).toInt(),
+      nameTh: json['name_th'] as String,
+      nameEn: json['name_en'] as String,
+      provinceId: (json['province_id'] as num).toInt(),
+    );
+  }
+}
+
+class SubDistrict {
+  SubDistrict({
+    required this.id,
+    required this.nameTh,
+    required this.nameEn,
+    required this.zipCode,
+    required this.districtId,
+  });
+
+  final int id;
+  final String nameTh;
+  final String nameEn;
+  final String zipCode;
+  final int districtId;
+
+  factory SubDistrict.fromJson(Map<String, dynamic> json) {
+    return SubDistrict(
+      id: (json['id'] as num).toInt(),
+      nameTh: json['name_th'] as String,
+      nameEn: json['name_en'] as String,
+      zipCode: json['zip_code'] as String,
+      districtId: (json['amphure_id'] as num).toInt(),
+    );
+  }
+}

--- a/lib/pages/addNewAddress.dart
+++ b/lib/pages/addNewAddress.dart
@@ -1,26 +1,85 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:delivery_app/components/custom_dialog.dart';
+import 'package:delivery_app/models/thai_address.dart';
+import 'package:delivery_app/services/thai_address_service.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
+import 'package:latlong2/latlong.dart';
 
 class AddNewAddress extends StatefulWidget {
-  final String? uid;
   const AddNewAddress({super.key, this.uid});
+
+  final String? uid;
 
   @override
   State<AddNewAddress> createState() => _AddNewAddressState();
 }
 
 class _AddNewAddressState extends State<AddNewAddress> {
-  final MapController mapController = MapController();
-  final TextEditingController addressNameCtl = TextEditingController();
-  final TextEditingController provinceCtl = TextEditingController();
-  final TextEditingController districtCtl = TextEditingController();
-  final TextEditingController subDistrictCtl = TextEditingController();
-  final TextEditingController postCodeCtl = TextEditingController();
-  final TextEditingController addressNumberCtl = TextEditingController();
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _labelController = TextEditingController();
+  final TextEditingController _addressNumberController = TextEditingController();
+  final TextEditingController _postalCodeController = TextEditingController();
+  final ThaiAddressService _thaiAddressService = ThaiAddressService();
+  final Dio _dio = Dio(
+    BaseOptions(headers: const {'User-Agent': 'DeliveryApp/1.0 (https://github.com)'}),
+  );
+
+  late final Future<void> _initialDataFuture;
+
+  List<Province> _provinces = <Province>[];
+  List<District> _districts = <District>[];
+  List<SubDistrict> _subDistricts = <SubDistrict>[];
+  Province? _selectedProvince;
+  District? _selectedDistrict;
+  SubDistrict? _selectedSubDistrict;
+
+  bool _loadingDistricts = false;
+  bool _loadingSubDistricts = false;
+  bool _isSaving = false;
+  bool _setAsDefault = false;
+
+  LatLng? _selectedLatLng;
+  String? _resolvedAddress;
+
+  String? _provinceError;
+  String? _districtError;
+  String? _subDistrictError;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialDataFuture = _loadInitialData();
+  }
+
+  Future<void> _loadInitialData() async {
+    try {
+      final provinces = await _thaiAddressService.getProvinces();
+      if (mounted) {
+        setState(() {
+          _provinces = provinces;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _provinceError = 'ไม่สามารถโหลดรายชื่อจังหวัดได้';
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _addressNumberController.dispose();
+    _postalCodeController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -43,100 +102,136 @@ class _AddNewAddressState extends State<AddNewAddress> {
           ),
         ),
         leading: IconButton(
-          onPressed: () {},
-          icon: Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () => context.pop(),
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(20.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            buildTextField(
-              label: 'ชื่อของที่อยู่',
-              hint: 'เช่น บ้าน, ที่ทำงาน',
-              controller: addressNameCtl,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 7),
-              child: Text(
-                'ที่อยู่',
-                style: const TextStyle(color: Color(0xFFBBB9B9), fontSize: 16),
-              ),
-            ),
-            FilledButton(
-              onPressed: () async {
-                // var postion = await _determinePosition();
-                // mapController;
-                // mapController.move(
-                //   LatLng(postion.latitude, postion.longitude),
-                //   13.0,
-                // );
-                context.pushNamed(
-                  'pickerAddress',
-                  queryParameters: {'uid': widget.uid ?? ''},
-                );
-              },
-              style: FilledButton.styleFrom(
-                backgroundColor: const Color(0xFF16A34A).withOpacity(0.25),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 16,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: const [
-                  Row(
-                    children: [
-                      Icon(Icons.location_on_outlined, color: Colors.white),
-                      SizedBox(width: 8),
-                      Text(
-                        'เลือกจากแผนที่',
-                        style: TextStyle(color: Colors.white, fontSize: 16),
+      body: SafeArea(
+        child: FutureBuilder<void>(
+          future: _initialDataFuture,
+          builder: (context, snapshot) {
+            final isLoading = snapshot.connectionState == ConnectionState.waiting &&
+                _provinces.isEmpty;
+            if (isLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return Form(
+              key: _formKey,
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildTextFormField(
+                      controller: _labelController,
+                      label: 'ชื่อของที่อยู่',
+                      hint: 'เช่น บ้าน, ที่ทำงาน',
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'กรุณาระบุชื่อของที่อยู่';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'ที่อยู่',
+                      style: Theme.of(context)
+                          .textTheme
+                          .titleMedium
+                          ?.copyWith(color: const Color(0xFFBBB9B9)),
+                    ),
+                    const SizedBox(height: 8),
+                    _buildPickFromMapButton(),
+                    if (_resolvedAddress != null) ...[
+                      const SizedBox(height: 12),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(14),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF1F2937),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.white10),
+                        ),
+                        child: Text(
+                          _resolvedAddress!,
+                          style: const TextStyle(color: Colors.white70, height: 1.4),
+                        ),
                       ),
                     ],
-                  ),
-                  Icon(Icons.chevron_right, color: Colors.white),
-                ],
+                    const SizedBox(height: 24),
+                    _buildProvinceDropdown(),
+                    const SizedBox(height: 16),
+                    _buildDistrictDropdown(),
+                    const SizedBox(height: 16),
+                    _buildSubDistrictDropdown(),
+                    const SizedBox(height: 16),
+                    _buildTextFormField(
+                      controller: _addressNumberController,
+                      label: 'เลขที่อยู่',
+                      hint: 'กรุณากรอกเลขที่อยู่และรายละเอียดเพิ่มเติม',
+                      maxLines: 2,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'กรุณากรอกเลขที่อยู่';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    _buildTextFormField(
+                      controller: _postalCodeController,
+                      label: 'รหัสไปรษณีย์',
+                      hint: 'กรุณากรอกรหัสไปรษณีย์',
+                      keyboardType: TextInputType.number,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'กรุณากรอกรหัสไปรษณีย์';
+                        }
+                        if (value.trim().length != 5) {
+                          return 'กรุณากรอกรหัสไปรษณีย์ 5 หลัก';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    SwitchListTile.adaptive(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text(
+                        'ตั้งเป็นที่อยู่หลัก',
+                        style: TextStyle(color: Colors.white),
+                      ),
+                      subtitle: const Text(
+                        'ระบบจะใช้ที่อยู่นี้เป็นค่าเริ่มต้นสำหรับการจัดส่ง',
+                        style: TextStyle(color: Colors.white60),
+                      ),
+                      value: _setAsDefault,
+                      onChanged: (value) {
+                        setState(() {
+                          _setAsDefault = value;
+                        });
+                      },
+                      activeColor: const Color(0xFF16A34A),
+                    ),
+                    if (_provinceError != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 12),
+                        child: Text(
+                          _provinceError!,
+                          style: const TextStyle(color: Colors.redAccent),
+                        ),
+                      ),
+                  ],
+                ),
               ),
-            ),
-
-            buildTextField(
-              label: 'จังหวัด',
-              hint: 'กรุณาเลือกจังหวัด',
-              controller: provinceCtl,
-            ),
-            buildTextField(
-              label: 'อำเภอ',
-              hint: 'กรุณาเลือกอำเภอ',
-              controller: districtCtl,
-            ),
-            buildTextField(
-              label: 'ตำบล',
-              hint: 'กรุณาเลือกตำบล',
-              controller: subDistrictCtl,
-            ),
-            buildTextField(
-              label: 'เลขที่อยู่',
-              hint: 'กรุณากรอกเลขที่อยู่',
-              controller: addressNumberCtl,
-            ),
-            buildTextField(
-              label: 'รหัสไปรษณีย์',
-              hint: 'กรุณากรอกรหัสไปรษณีย์',
-              controller: postCodeCtl,
-            ),
-          ],
+            );
+          },
         ),
       ),
       bottomNavigationBar: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 0, 20, 40),
+        padding: const EdgeInsets.fromLTRB(20, 0, 20, 32),
         child: ElevatedButton(
-          onPressed: addNewAddress,
+          onPressed: _isSaving ? null : _saveAddress,
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color(0xFF16A34A),
             padding: const EdgeInsets.symmetric(vertical: 15),
@@ -144,55 +239,178 @@ class _AddNewAddressState extends State<AddNewAddress> {
               borderRadius: BorderRadius.circular(10),
             ),
           ),
-          child: const Text(
-            'บันทึกที่อยู่',
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
+          child: _isSaving
+              ? const SizedBox(
+                  height: 22,
+                  width: 22,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 3,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : const Text(
+                  'บันทึกที่อยู่',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
         ),
       ),
     );
   }
 
-  void addNewAddress() async {
-    final collectionName = "addresses";
-    print('Add new address for user: ${widget.uid}');
-
-    final docRef = FirebaseFirestore.instance.collection(collectionName).doc();
-    final newAddress = {
-      'addr_id': docRef.id,
-      'uid': widget.uid,
-      'addressName': addressNameCtl.text,
-      'fullAddress':
-          '${addressNumberCtl.text} ${subDistrictCtl.text} ${districtCtl.text} ${provinceCtl.text} ${postCodeCtl.text}',
-    };
-    await docRef.set(newAddress);
-
-    if (!mounted) return;
-
-    await showSuccessDialog(
-      context,
-      title: 'สำเร็จ!',
-      message: 'บันทึกที่อยู่เรียบร้อยแล้ว 🎉',
+  Widget _buildPickFromMapButton() {
+    return FilledButton(
+      onPressed: _handlePickFromMap,
+      style: FilledButton.styleFrom(
+        backgroundColor: const Color(0xFF16A34A).withOpacity(0.25),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: const [
+          Row(
+            children: [
+              Icon(Icons.location_on_outlined, color: Colors.white),
+              SizedBox(width: 8),
+              Text(
+                'เลือกจากแผนที่',
+                style: TextStyle(color: Colors.white, fontSize: 16),
+              ),
+            ],
+          ),
+          Icon(Icons.chevron_right, color: Colors.white),
+        ],
+      ),
     );
   }
-}
 
-Widget buildTextField({
-  required String label,
-  required String hint,
-  required TextEditingController controller,
-  bool obscure = false,
-  Widget? suffix,
-  TextInputType? type,
-  bool readOnly = false,
-}) {
-  return Padding(
-    padding: const EdgeInsets.symmetric(vertical: 6),
-    child: Column(
+  Widget _buildProvinceDropdown() {
+    return DropdownButtonFormField<Province>(
+      value: _selectedProvince,
+      isExpanded: true,
+      decoration: _dropdownDecoration('จังหวัด'),
+      items: _provinces
+          .map(
+            (province) => DropdownMenuItem<Province>(
+              value: province,
+              child: Text(province.nameTh, overflow: TextOverflow.ellipsis),
+            ),
+          )
+          .toList(),
+      onChanged: (value) {
+        if (value == null) return;
+        _onProvinceChanged(value);
+      },
+      validator: (_) {
+        if (_selectedProvince == null) {
+          return 'กรุณาเลือกจังหวัด';
+        }
+        return null;
+      },
+    );
+  }
+
+  Widget _buildDistrictDropdown() {
+    return DropdownButtonFormField<District>(
+      value: _selectedDistrict,
+      isExpanded: true,
+      decoration: _dropdownDecoration('อำเภอ'),
+      items: _districts
+          .map(
+            (district) => DropdownMenuItem<District>(
+              value: district,
+              child: Text(district.nameTh, overflow: TextOverflow.ellipsis),
+            ),
+          )
+          .toList(),
+      onChanged: _districts.isEmpty
+          ? null
+          : (value) {
+              if (value == null) return;
+              _onDistrictChanged(value);
+            },
+      validator: (_) {
+        if (_selectedProvince == null) {
+          return 'กรุณาเลือกจังหวัดก่อน';
+        }
+        if (_selectedDistrict == null) {
+          return _districtError ?? 'กรุณาเลือกอำเภอ';
+        }
+        return null;
+      },
+      disabledHint: _loadingDistricts
+          ? const Text('กำลังโหลดอำเภอ...', style: TextStyle(color: Colors.white54))
+          : const Text('เลือกจังหวัดก่อน', style: TextStyle(color: Colors.white54)),
+    );
+  }
+
+  Widget _buildSubDistrictDropdown() {
+    return DropdownButtonFormField<SubDistrict>(
+      value: _selectedSubDistrict,
+      isExpanded: true,
+      decoration: _dropdownDecoration('ตำบล'),
+      items: _subDistricts
+          .map(
+            (subDistrict) => DropdownMenuItem<SubDistrict>(
+              value: subDistrict,
+              child: Text(subDistrict.nameTh, overflow: TextOverflow.ellipsis),
+            ),
+          )
+          .toList(),
+      onChanged: _subDistricts.isEmpty
+          ? null
+          : (value) {
+              if (value == null) return;
+              _onSubDistrictChanged(value);
+            },
+      validator: (_) {
+        if (_selectedDistrict == null) {
+          return 'กรุณาเลือกอำเภอก่อน';
+        }
+        if (_selectedSubDistrict == null) {
+          return _subDistrictError ?? 'กรุณาเลือกตำบล';
+        }
+        return null;
+      },
+      disabledHint: _loadingSubDistricts
+          ? const Text('กำลังโหลดตำบล...', style: TextStyle(color: Colors.white54))
+          : const Text('เลือกอำเภอก่อน', style: TextStyle(color: Colors.white54)),
+    );
+  }
+
+  InputDecoration _dropdownDecoration(String label) {
+    return InputDecoration(
+      labelText: label,
+      labelStyle: const TextStyle(color: Color(0xFFBBB9B9), fontSize: 16),
+      filled: true,
+      fillColor: Colors.white,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Color(0xFFC7C0C0), width: 1.2),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Color(0xFFC7C0C0), width: 1.2),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+    );
+  }
+
+  Widget _buildTextFormField({
+    required TextEditingController controller,
+    required String label,
+    required String hint,
+    String? Function(String?)? validator,
+    TextInputType? keyboardType,
+    int maxLines = 1,
+  }) {
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
@@ -200,66 +418,374 @@ Widget buildTextField({
           style: const TextStyle(color: Color(0xFFBBB9B9), fontSize: 16),
         ),
         const SizedBox(height: 6),
-        TextField(
+        TextFormField(
           controller: controller,
-          readOnly: readOnly,
-          style: const TextStyle(color: Colors.black),
-          obscureText: obscure,
-          keyboardType: type,
+          validator: validator,
+          keyboardType: keyboardType,
+          maxLines: maxLines,
+          style: const TextStyle(color: Colors.black87),
           decoration: InputDecoration(
             hintText: hint,
             hintStyle: const TextStyle(color: Color(0xFF848484), fontSize: 14),
-            suffixIcon: suffix,
             filled: true,
             fillColor: Colors.white,
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(5),
-              borderSide: const BorderSide(
-                color: Color(0xFFC7C0C0),
-                width: 1.5,
-              ),
+              borderRadius: BorderRadius.circular(8),
+              borderSide: const BorderSide(color: Color(0xFFC7C0C0), width: 1.2),
             ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: const BorderSide(color: Color(0xFFC7C0C0), width: 1.2),
+            ),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
           ),
         ),
       ],
-    ),
-  );
-}
-
-Future<Position> _determinePosition() async {
-  bool serviceEnabled;
-  LocationPermission permission;
-
-  // Test if location services are enabled.
-  serviceEnabled = await Geolocator.isLocationServiceEnabled();
-  if (!serviceEnabled) {
-    // Location services are not enabled don't continue
-    // accessing the position and request users of the
-    // App to enable the location services.
-    return Future.error('Location services are disabled.');
-  }
-
-  permission = await Geolocator.checkPermission();
-  if (permission == LocationPermission.denied) {
-    permission = await Geolocator.requestPermission();
-    if (permission == LocationPermission.denied) {
-      // Permissions are denied, next time you could try
-      // requesting permissions again (this is also where
-      // Android's shouldShowRequestPermissionRationale
-      // returned true. According to Android guidelines
-      // your App should show an explanatory UI now.
-      return Future.error('Location permissions are denied');
-    }
-  }
-
-  if (permission == LocationPermission.deniedForever) {
-    // Permissions are denied forever, handle appropriately.
-    return Future.error(
-      'Location permissions are permanently denied, we cannot request permissions.',
     );
   }
 
-  // When we reach here, permissions are granted and we can
-  // continue accessing the position of the device.
-  return await Geolocator.getCurrentPosition();
+  Future<void> _handlePickFromMap() async {
+    final result = await context.pushNamed<Map<String, dynamic>>(
+      'pickerAddress',
+      queryParameters: {'uid': widget.uid ?? ''},
+    );
+    if (result == null) {
+      return;
+    }
+
+    final latlng = result['latlng'] as Map<String, dynamic>?;
+    final addressText = result['address'] as String?;
+    final components =
+        (result['addressComponents'] as Map?)?.cast<String, dynamic>();
+
+    if (latlng != null) {
+      final lat = (latlng['lat'] as num?)?.toDouble();
+      final lng = (latlng['lng'] as num?)?.toDouble();
+      if (lat != null && lng != null) {
+        _selectedLatLng = LatLng(lat, lng);
+      }
+    }
+
+    setState(() {
+      _resolvedAddress = addressText;
+    });
+
+    if (components != null) {
+      await _applyAddressComponents(components);
+    }
+  }
+
+  Future<void> _applyAddressComponents(Map<String, dynamic> components) async {
+    await _initialDataFuture;
+
+    final provinceName = _sanitizeName(
+      components['state'] ?? components['province'] ?? components['region'],
+    );
+    if (provinceName != null && _provinces.isNotEmpty) {
+      final province = _provinces.firstWhere(
+        (element) =>
+            _normalize(element.nameTh) == _normalize(provinceName) ||
+            _normalize(element.nameEn) == _normalize(provinceName),
+        orElse: () => _provinces.first,
+      );
+      await _onProvinceChanged(province, fromAutoFill: true);
+    }
+
+    final districtName = _sanitizeName(
+      components['county'] ??
+          components['district'] ??
+          components['city'] ??
+          components['municipality'],
+    );
+    if (districtName != null && _selectedProvince != null && _districts.isNotEmpty) {
+      final match = _districts.firstWhere(
+        (element) =>
+            _normalize(element.nameTh) == _normalize(districtName) ||
+            _normalize(element.nameEn) == _normalize(districtName),
+        orElse: () => _districts.first,
+      );
+      await _onDistrictChanged(match, fromAutoFill: true);
+    }
+
+    final subDistrictName = _sanitizeName(
+      components['suburb'] ??
+          components['town'] ??
+          components['village'] ??
+          components['subdistrict'] ??
+          components['neighbourhood'],
+    );
+    if (subDistrictName != null &&
+        _selectedDistrict != null &&
+        _subDistricts.isNotEmpty) {
+      final match = _subDistricts.firstWhere(
+        (element) =>
+            _normalize(element.nameTh) == _normalize(subDistrictName) ||
+            _normalize(element.nameEn) == _normalize(subDistrictName),
+        orElse: () => _subDistricts.first,
+      );
+      _onSubDistrictChanged(match);
+    }
+
+    final postalCode = components['postcode'] as String?;
+    if (postalCode != null && postalCode.length == 5) {
+      _postalCodeController.text = postalCode;
+    }
+
+    final houseNumber = components['house_number'] as String?;
+    final road = components['road'] as String?;
+    final neighbourhood = components['residential'] as String?;
+    final line = [houseNumber, road, neighbourhood]
+        .where((element) => element != null && element.toString().isNotEmpty)
+        .join(' ');
+    if (line.isNotEmpty) {
+      _addressNumberController.text = line;
+    }
+    setState(() {});
+  }
+
+  Future<void> _onProvinceChanged(Province province,
+      {bool fromAutoFill = false}) async {
+    setState(() {
+      _selectedProvince = province;
+      _selectedDistrict = null;
+      _selectedSubDistrict = null;
+      _districts = <District>[];
+      _subDistricts = <SubDistrict>[];
+      _postalCodeController.clear();
+      _districtError = null;
+      _subDistrictError = null;
+      _loadingDistricts = true;
+    });
+
+    try {
+      final districts = await _thaiAddressService.getDistricts(province.id);
+      if (!mounted) return;
+      setState(() {
+        _districts = districts;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _districtError = 'โหลดข้อมูลอำเภอไม่สำเร็จ';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loadingDistricts = false;
+        });
+      }
+    }
+
+    if (!fromAutoFill) {
+      _addressNumberController.clear();
+      _postalCodeController.clear();
+    }
+  }
+
+  Future<void> _onDistrictChanged(District district,
+      {bool fromAutoFill = false}) async {
+    setState(() {
+      _selectedDistrict = district;
+      _selectedSubDistrict = null;
+      _subDistricts = <SubDistrict>[];
+      _subDistrictError = null;
+      _loadingSubDistricts = true;
+    });
+
+    try {
+      final subDistricts =
+          await _thaiAddressService.getSubDistricts(district.id);
+      if (!mounted) return;
+      setState(() {
+        _subDistricts = subDistricts;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _subDistrictError = 'โหลดข้อมูลตำบลไม่สำเร็จ';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loadingSubDistricts = false;
+        });
+      }
+    }
+
+    if (!fromAutoFill) {
+      _postalCodeController.clear();
+    }
+  }
+
+  void _onSubDistrictChanged(SubDistrict subDistrict) {
+    setState(() {
+      _selectedSubDistrict = subDistrict;
+      _postalCodeController.text = subDistrict.zipCode;
+    });
+  }
+
+  Future<void> _saveAddress() async {
+    FocusScope.of(context).unfocus();
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+    });
+
+    try {
+      final latLng = await _ensureLatLng();
+      if (latLng == null) {
+        throw Exception('ไม่พบพิกัดของที่อยู่นี้');
+      }
+
+      final uid = widget.uid;
+      if (uid == null || uid.isEmpty) {
+        throw Exception('ไม่พบผู้ใช้งาน');
+      }
+
+      final collection = FirebaseFirestore.instance.collection('addresses');
+      final existingSnapshot = await collection
+          .where('uid', isEqualTo: uid)
+          .get();
+      final shouldSetDefault = _setAsDefault || existingSnapshot.docs.isEmpty;
+
+      final docRef = collection.doc();
+      final now = FieldValue.serverTimestamp();
+
+      if (_setAsDefault) {
+        for (final doc in existingSnapshot.docs
+            .where((element) => (element.data()['is_default'] as num?)?.toInt() == 0)) {
+          await doc.reference.update({'is_default': 1});
+        }
+      }
+
+      final newAddress = <String, dynamic>{
+        'addr_id': docRef.id,
+        'uid': uid,
+        'label': _labelController.text.trim(),
+        'fullAddress': _buildFullAddress(),
+        'province': _selectedProvince?.nameTh,
+        'district': _selectedDistrict?.nameTh,
+        'subDistrict': _selectedSubDistrict?.nameTh,
+        'postalCode': _postalCodeController.text.trim(),
+        'lat': latLng.latitude,
+        'lng': latLng.longitude,
+        'is_default': shouldSetDefault ? 0 : 1,
+        'create_at': now,
+        'update_at': now,
+      };
+
+      await docRef.set(newAddress);
+
+      if (!mounted) return;
+
+      await showSuccessDialog(
+        context,
+        title: 'สำเร็จ!',
+        message: 'บันทึกที่อยู่เรียบร้อยแล้ว 🎉',
+      );
+      if (mounted) {
+        context.pop(true);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          backgroundColor: Colors.redAccent,
+          content: Text(e.toString()),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  String _buildFullAddress() {
+    final parts = <String?>[
+      _addressNumberController.text.trim(),
+      _selectedSubDistrict?.nameTh,
+      _selectedDistrict?.nameTh,
+      _selectedProvince?.nameTh,
+      _postalCodeController.text.trim(),
+    ];
+    return parts
+        .where((element) => element != null && element!.isNotEmpty)
+        .join(' ');
+  }
+
+  Future<LatLng?> _ensureLatLng() async {
+    if (_selectedLatLng != null) {
+      return _selectedLatLng;
+    }
+
+    final query = [
+      _addressNumberController.text.trim(),
+      _selectedSubDistrict?.nameTh,
+      _selectedDistrict?.nameTh,
+      _selectedProvince?.nameTh,
+      'ประเทศไทย',
+    ]
+        .where((element) => element != null && element!.isNotEmpty)
+        .join(' ');
+
+    if (query.isEmpty) {
+      return null;
+    }
+
+    final url =
+        'https://nominatim.openstreetmap.org/search?format=jsonv2&q=${Uri.encodeComponent(query)}&limit=1';
+    try {
+      final response = await _dio.get(url);
+      final results = response.data as List<dynamic>;
+      if (results.isEmpty) {
+        return null;
+      }
+      final first = results.first as Map<String, dynamic>;
+      final lat = double.tryParse(first['lat'] as String? ?? '');
+      final lon = double.tryParse(first['lon'] as String? ?? '');
+      if (lat == null || lon == null) {
+        return null;
+      }
+      _selectedLatLng = LatLng(lat, lon);
+      return _selectedLatLng;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String? _sanitizeName(dynamic value) {
+    if (value == null) return null;
+    var name = value.toString();
+    name = name.replaceAll(RegExp(r'^จังหวัด'), '');
+    name = name.replaceAll(RegExp(r'^เขต'), '');
+    name = name.replaceAll(RegExp(r'^อำเภอ'), '');
+    name = name.replaceAll(RegExp(r'^เทศบาล'), '');
+    name = name.replaceAll(RegExp(r'^ตำบล'), '');
+    name = name.replaceAll(RegExp(r'^แขวง'), '');
+    name = name.replaceAll(RegExp(r'^ต\.'), '');
+    name = name.replaceAll(RegExp(r'^อ\.'), '');
+    name = name.replaceAll(RegExp(r'^จ\.'), '');
+    return name.trim();
+  }
+
+  String _normalize(String? value) {
+    if (value == null) {
+      return '';
+    }
+    return value
+        .toLowerCase()
+        .replaceAll(' ', '')
+        .replaceAll('จังหวัด', '')
+        .replaceAll('เขต', '')
+        .replaceAll('อำเภอ', '')
+        .replaceAll('ตำบล', '')
+        .replaceAll('แขวง', '');
+  }
 }

--- a/lib/pages/pickAddressMap.dart
+++ b/lib/pages/pickAddressMap.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:dio/dio.dart';
 import 'package:latlong2/latlong.dart';
 
 class PickAddressMapPage extends StatefulWidget {
@@ -15,7 +16,11 @@ class PickAddressMapPage extends StatefulWidget {
 
 class _PickAddressMapPageState extends State<PickAddressMapPage> {
   final MapController _mapController = MapController();
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(
+    BaseOptions(headers: const {'User-Agent': 'DeliveryApp/1.0 (https://github.com)'}),
+  );
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
 
   // --- State Variables ---
   LatLng? _currentCenter;
@@ -23,41 +28,68 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
   bool _isFirstTimeLoading = true; // สำหรับโหลดครั้งแรกที่เข้าหน้า
   bool _isGeocoding = false; // สำหรับตอนกำลังแปลงพิกัดเป็นที่อยู่
   Timer? _debounce;
+  Timer? _searchDebounce;
   String? _errorMessage;
+  bool _isSearching = false;
+  List<Map<String, dynamic>> _searchResults = <Map<String, dynamic>>[];
+  Map<String, dynamic>? _currentAddressComponents;
 
   @override
   void initState() {
     super.initState();
     _determineInitialPosition();
+    _searchFocusNode.addListener(() {
+      if (!_searchFocusNode.hasFocus) {
+        setState(() {
+          _searchResults = <Map<String, dynamic>>[];
+        });
+      }
+    });
   }
 
   @override
   void dispose() {
     _debounce?.cancel();
+    _searchDebounce?.cancel();
     _mapController.dispose();
+    _searchController.dispose();
+    _searchFocusNode.dispose();
     super.dispose();
   }
 
   // Step 1: หาตำแหน่งเริ่มต้นของผู้ใช้ (ทำงานครั้งเดียว)
   Future<void> _determineInitialPosition() async {
     try {
+      final hasPermission = await _ensureLocationPermission();
+      LatLng fallback = const LatLng(13.7563, 100.5018);
+      if (!hasPermission) {
+        setState(() {
+          _currentCenter = fallback;
+          _isFirstTimeLoading = false;
+          _errorMessage = 'ไม่สามารถเข้าถึงตำแหน่งปัจจุบันได้';
+          _startGeocode(_currentCenter!);
+        });
+        return;
+      }
+
       final position = await Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.high,
       );
+      final center = LatLng(position.latitude, position.longitude);
       setState(() {
-        _currentCenter = LatLng(position.latitude, position.longitude);
+        _currentCenter = center;
         _isFirstTimeLoading = false;
-        _mapController.move(_currentCenter!, 17.0);
-        _startGeocode(_currentCenter!);
+        _errorMessage = null;
       });
+      _mapController.move(center, 17.0);
+      _startGeocode(center);
     } catch (e) {
-      // กรณีหาตำแหน่งไม่ได้จริงๆ ให้ใช้ค่าเริ่มต้น (กรุงเทพ)
       setState(() {
         _currentCenter = const LatLng(13.7563, 100.5018);
         _isFirstTimeLoading = false;
         _errorMessage = "ไม่สามารถเข้าถึงตำแหน่งปัจจุบันได้";
-        _startGeocode(_currentCenter!);
       });
+      _startGeocode(_currentCenter!);
     }
   }
 
@@ -65,7 +97,7 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
   void _startGeocode(LatLng point) {
     if (_debounce?.isActive ?? false) _debounce!.cancel();
     _debounce = Timer(const Duration(milliseconds: 300), () {
-      // ลดเวลา debounce ลงเล็กน้อย
+      _currentCenter = point;
       _reverseGeocode(point);
     });
   }
@@ -80,14 +112,15 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
         'https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${point.latitude}&lon=${point.longitude}&accept-language=th';
 
     try {
-      final response = await _dio.get(
-        url,
-        options: Options(headers: {'User-Agent': 'Stegosight Flutter App'}),
-      );
+      final response = await _dio.get(url);
       if (response.statusCode == 200 && mounted) {
         setState(() {
           _currentAddress =
               response.data['display_name'] ?? 'ไม่พบข้อมูลที่อยู่';
+          final rawAddress = response.data['address'];
+          if (rawAddress is Map<String, dynamic>) {
+            _currentAddressComponents = rawAddress;
+          }
           _errorMessage = null;
         });
       }
@@ -151,8 +184,11 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
         initialCenter: _currentCenter ?? const LatLng(13.7563, 100.5018),
         initialZoom: 17.0,
         onPositionChanged: (position, hasGesture) {
-          if (hasGesture && position.center != null) {
-            _startGeocode(position.center!);
+          if (position.center != null) {
+            _currentCenter = position.center;
+            if (hasGesture) {
+              _startGeocode(position.center!);
+            }
           }
         },
       ),
@@ -181,32 +217,91 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
       top: MediaQuery.of(context).padding.top + 10,
       left: 15,
       right: 15,
-      child: Row(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          FloatingActionButton.small(
-            onPressed: () => Navigator.of(context).pop(),
-            backgroundColor: Colors.white,
-            child: const Icon(Icons.arrow_back, color: Colors.black),
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Card(
-              elevation: 4,
-              color: Color.fromARGB(255, 255, 255, 255),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(30),
+          Row(
+            children: [
+              FloatingActionButton.small(
+                onPressed: () => Navigator.of(context).pop(),
+                backgroundColor: Colors.white,
+                child: const Icon(Icons.arrow_back, color: Colors.black),
               ),
-              child: const TextField(
-                decoration: InputDecoration(
-                  hintText: 'ค้นหาที่อยู่หรือชื่ออาคาร',
-                  prefixIcon: Icon(Icons.search),
-                  border: InputBorder.none,
-                  contentPadding: EdgeInsets.symmetric(vertical: 15),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Card(
+                  elevation: 4,
+                  color: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _searchController,
+                          focusNode: _searchFocusNode,
+                          onChanged: _onSearchChanged,
+                          textInputAction: TextInputAction.search,
+                          onSubmitted: _performSearch,
+                          decoration: const InputDecoration(
+                            hintText: 'ค้นหาที่อยู่หรือชื่ออาคาร',
+                            prefixIcon: Icon(Icons.search),
+                            border: InputBorder.none,
+                            contentPadding: EdgeInsets.symmetric(vertical: 15),
+                          ),
+                          style: const TextStyle(color: Colors.black),
+                        ),
+                      ),
+                      if (_isSearching)
+                        const Padding(
+                          padding: EdgeInsets.only(right: 16),
+                          child: SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        ),
+                    ],
+                  ),
                 ),
-                style: TextStyle(color: Colors.black),
+              ),
+            ],
+          ),
+          if (_searchResults.isNotEmpty)
+            Container(
+              margin: const EdgeInsets.only(top: 8),
+              constraints: const BoxConstraints(maxHeight: 260),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.15),
+                    blurRadius: 8,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: ListView.separated(
+                shrinkWrap: true,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemCount: _searchResults.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (context, index) {
+                  final result = _searchResults[index];
+                  final title = result['display_name'] as String? ?? '';
+                  return ListTile(
+                    onTap: () => _selectSearchResult(result),
+                    leading: const Icon(Icons.location_pin, color: Colors.green),
+                    title: Text(
+                      title,
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                  );
+                },
               ),
             ),
-          ),
         ],
       ),
     );
@@ -278,10 +373,14 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () {
-                    if (Navigator.canPop(context)) {
+                    if (Navigator.canPop(context) && _currentCenter != null) {
                       Navigator.pop(context, {
                         'address': _currentAddress,
-                        'latlng': _currentCenter,
+                        'latlng': {
+                          'lat': _currentCenter!.latitude,
+                          'lng': _currentCenter!.longitude,
+                        },
+                        'addressComponents': _currentAddressComponents,
                       });
                     }
                   },
@@ -307,5 +406,100 @@ class _PickAddressMapPageState extends State<PickAddressMapPage> {
         ),
       ),
     );
+  }
+
+  Future<bool> _ensureLocationPermission() async {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'กรุณาเปิดบริการระบุตำแหน่ง';
+        });
+      }
+      return false;
+    }
+
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+
+    if (permission == LocationPermission.denied ||
+        permission == LocationPermission.deniedForever) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'โปรดอนุญาตการเข้าถึงตำแหน่ง';
+        });
+      }
+      return false;
+    }
+    return true;
+  }
+
+  void _onSearchChanged(String value) {
+    _searchDebounce?.cancel();
+    final trimmed = value.trim();
+    if (trimmed.length < 3) {
+      setState(() {
+        _searchResults = <Map<String, dynamic>>[];
+      });
+      return;
+    }
+    _searchDebounce = Timer(const Duration(milliseconds: 350), () {
+      _performSearch(trimmed);
+    });
+  }
+
+  Future<void> _performSearch(String query) async {
+    if (query.isEmpty) return;
+    setState(() {
+      _isSearching = true;
+    });
+
+    final url =
+        'https://nominatim.openstreetmap.org/search?format=jsonv2&q=${Uri.encodeComponent(query)}&addressdetails=1&accept-language=th&limit=6';
+    try {
+      final response = await _dio.get(url);
+      final data = response.data;
+      if (data is List) {
+        setState(() {
+          _searchResults = data
+              .whereType<Map>()
+              .map((e) => Map<String, dynamic>.from(e as Map<String, dynamic>))
+              .toList(growable: false);
+        });
+      }
+    } catch (_) {
+      setState(() {
+        _searchResults = <Map<String, dynamic>>[];
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSearching = false;
+        });
+      }
+    }
+  }
+
+  void _selectSearchResult(Map<String, dynamic> result) {
+    final lat = double.tryParse(result['lat'] as String? ?? '');
+    final lon = double.tryParse(result['lon'] as String? ?? '');
+    if (lat == null || lon == null) {
+      return;
+    }
+    final center = LatLng(lat, lon);
+    final address = result['address'];
+    setState(() {
+      _searchController.text = result['display_name'] as String? ?? '';
+      _searchResults = <Map<String, dynamic>>[];
+      _currentCenter = center;
+      if (address is Map<String, dynamic>) {
+        _currentAddressComponents = address;
+      }
+    });
+    FocusScope.of(context).unfocus();
+    _mapController.move(center, 17.0);
+    _startGeocode(center);
   }
 }

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -115,10 +115,10 @@ class _ProfilePageState extends State<ProfilePage> {
                     Icons.location_on_outlined,
                     'ที่อยู่',
                     onTap: () {
-                      print('Going to address with uid=${widget.uid}');
+                      final uid = widget.uid ?? _profile.uid;
                       context.pushNamed(
                         'address',
-                        queryParameters: {'uid': widget.uid},
+                        queryParameters: {'uid': uid},
                       );
                     },
                   ),

--- a/lib/pages/useraddress.dart
+++ b/lib/pages/useraddress.dart
@@ -1,23 +1,30 @@
-import 'dart:developer';
 import 'package:bootstrap_icons/bootstrap_icons.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:delivery_app/models/address.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 class UserAddressPage extends StatefulWidget {
-  final String? uid;
   const UserAddressPage({super.key, this.uid});
+
+  final String? uid;
 
   @override
   State<UserAddressPage> createState() => _UserAddressPageState();
 }
 
 class _UserAddressPageState extends State<UserAddressPage> {
-  List<Map<String, dynamic>> addresses = [];
+  late final Stream<QuerySnapshot<Map<String, dynamic>>> _addressStream;
+
   @override
   void initState() {
     super.initState();
-    LoadAddresses();
+    _addressStream = FirebaseFirestore.instance
+        .collection('addresses')
+        .where('uid', isEqualTo: widget.uid)
+        .orderBy('is_default')
+        .orderBy('create_at', descending: true)
+        .snapshots();
   }
 
   @override
@@ -42,101 +49,63 @@ class _UserAddressPageState extends State<UserAddressPage> {
           ),
         ),
         leading: IconButton(
-          onPressed: () {},
-          icon: Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () => context.pop(),
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
         ),
       ),
-      body: Expanded(
-        child: ListView.builder(
-          padding: const EdgeInsets.all(10),
-          itemCount: addresses.length,
-          itemBuilder: (context, index) {
-            final addr = addresses[index];
-            return Padding(
-              padding: const EdgeInsets.symmetric(vertical: 6),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: const Color(0xFFD9D9D9).withOpacity(0.05),
-                  borderRadius: BorderRadius.circular(10),
-                  border: Border.all(
-                    color: const Color(0xFF16A34A).withOpacity(0.3),
-                    width: 1,
-                  ),
-                ),
-                padding: const EdgeInsets.all(10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Icon(
-                              BootstrapIcons.geo_alt,
-                              color: Color(0xFF16A34A),
-                              size: 25,
-                            ),
-                            const SizedBox(width: 12),
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  addr['addressName'] ?? 'ไม่ระบุชื่อที่อยู่',
-                                  style: const TextStyle(
-                                    fontSize: 16,
-                                    color: Colors.white,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                                SizedBox(
-                                  width:
-                                      MediaQuery.of(context).size.width * 0.7,
-                                  child: Text(
-                                    addr['fullAddress'] ?? '-',
-                                    softWrap: true,
-                                    style: const TextStyle(
-                                      fontSize: 14,
-                                      color: Colors.white70,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                        Expanded(
-                          child: IconButton(
-                            onPressed: () {
-                              print('Edit address: ${addr['addr_id']}');
-                            },
-                            icon: const Icon(
-                              BootstrapIcons.pencil_square,
-                              color: Color(0xFF16A34A),
-                              size: 22,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
-      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                stream: _addressStream,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
 
+                  if (snapshot.hasError) {
+                    return Center(
+                      child: Text(
+                        'เกิดข้อผิดพลาดในการโหลดข้อมูล',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyLarge
+                            ?.copyWith(color: Colors.redAccent),
+                      ),
+                    );
+                  }
+
+                  final docs = snapshot.data?.docs ?? [];
+                  if (docs.isEmpty) {
+                    return _buildEmptyState(context);
+                  }
+
+                  final addresses =
+                      docs.map(Address.fromFirestore).toList(growable: false);
+
+                  return ListView.separated(
+                    padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+                    itemCount: addresses.length,
+                    separatorBuilder: (_, __) => const SizedBox(height: 12),
+                    itemBuilder: (context, index) {
+                      final address = addresses[index];
+                      return _AddressTile(address: address);
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
       bottomNavigationBar: Padding(
-        padding: const EdgeInsets.fromLTRB(10, 0, 10, 20),
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         child: SizedBox(
           width: double.infinity,
           child: OutlinedButton.icon(
-            onPressed: () {
-              context.pushNamed(
+            onPressed: () async {
+              await context.pushNamed(
                 'addnewaddress',
                 queryParameters: {'uid': widget.uid},
               );
@@ -159,7 +128,7 @@ class _UserAddressPageState extends State<UserAddressPage> {
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(10),
               ),
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
             ),
           ),
         ),
@@ -167,20 +136,137 @@ class _UserAddressPageState extends State<UserAddressPage> {
     );
   }
 
-  Future<void> LoadAddresses() async {
-    log('coming LoadAddresses');
-    final uid = widget.uid;
-    log('Checking UID: $uid');
-    final snapshot = await FirebaseFirestore.instance
-        .collection('addresses')
-        .where('uid', isEqualTo: uid)
-        .get();
-    log('Found ${snapshot.docs.length} documents');
-    for (final doc in snapshot.docs) {
-      log('DocID: ${doc.id} => ${doc.data()}');
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Icon(
+            BootstrapIcons.geo_alt,
+            color: Color(0xFF16A34A),
+            size: 56,
+          ),
+          SizedBox(height: 16),
+          Text(
+            'ยังไม่มีที่อยู่ที่บันทึกไว้',
+            style: TextStyle(color: Colors.white70, fontSize: 16),
+          ),
+          SizedBox(height: 8),
+          Text(
+            'กดปุ่มด้านล่างเพื่อเพิ่มที่อยู่ใหม่',
+            style: TextStyle(color: Colors.white60, fontSize: 14),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
-      addresses = snapshot.docs.map((doc) => doc.data()).toList();
-      setState(() {});
-    }
+class _AddressTile extends StatelessWidget {
+  const _AddressTile({required this.address});
+
+  final Address address;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDefault = address.isDefault == 0;
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFF1F2937),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isDefault ? const Color(0xFF16A34A) : Colors.white12,
+          width: 1.3,
+        ),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(
+                BootstrapIcons.geo_alt,
+                color: Color(0xFF16A34A),
+                size: 26,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            address.label.isNotEmpty
+                                ? address.label
+                                : 'ไม่ระบุชื่อที่อยู่',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        if (isDefault)
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                              vertical: 4,
+                            ),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF16A34A).withOpacity(0.15),
+                              borderRadius: BorderRadius.circular(50),
+                            ),
+                            child: const Text(
+                              'ค่าเริ่มต้น',
+                              style: TextStyle(
+                                color: Color(0xFF16A34A),
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      address.fullAddress,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: Colors.white70,
+                        height: 1.4,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (address.lat != null && address.lng != null) ...[
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                const Icon(
+                  BootstrapIcons.pin_map,
+                  color: Colors.white60,
+                  size: 16,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  '${address.lat?.toStringAsFixed(6)}, ${address.lng?.toStringAsFixed(6)}',
+                  style: const TextStyle(
+                    color: Colors.white60,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
   }
 }

--- a/lib/services/thai_address_service.dart
+++ b/lib/services/thai_address_service.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+import 'package:delivery_app/models/thai_address.dart';
+
+class ThaiAddressService {
+  ThaiAddressService({Dio? dio})
+      : _dio = dio ?? Dio(BaseOptions(headers: _defaultHeaders));
+
+  static const _defaultHeaders = <String, dynamic>{
+    'User-Agent': 'DeliveryApp/1.0 (https://github.com)',
+  };
+
+  final Dio _dio;
+  List<Province>? _cachedProvinces;
+  List<District>? _cachedDistricts;
+  List<SubDistrict>? _cachedSubDistricts;
+
+  static const _provinceUrl =
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_province.json';
+  static const _districtUrl =
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_amphure.json';
+  static const _subDistrictUrl =
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_tambon.json';
+
+  Future<List<Province>> getProvinces() async {
+    if (_cachedProvinces != null) {
+      return _cachedProvinces!;
+    }
+    final response = await _dio.get(_provinceUrl);
+    final data = response.data as List<dynamic>;
+    _cachedProvinces = data
+        .map((e) =>
+            Province.fromJson(Map<String, dynamic>.from(e as Map<String, dynamic>)))
+        .toList()
+      ..sort((a, b) => a.nameTh.compareTo(b.nameTh));
+    return _cachedProvinces!;
+  }
+
+  Future<List<District>> getDistricts(int provinceId) async {
+    _cachedDistricts ??= await _loadDistricts();
+    return _cachedDistricts!
+        .where((district) => district.provinceId == provinceId)
+        .toList()
+      ..sort((a, b) => a.nameTh.compareTo(b.nameTh));
+  }
+
+  Future<List<SubDistrict>> getSubDistricts(int districtId) async {
+    _cachedSubDistricts ??= await _loadSubDistricts();
+    return _cachedSubDistricts!
+        .where((sub) => sub.districtId == districtId)
+        .toList()
+      ..sort((a, b) => a.nameTh.compareTo(b.nameTh));
+  }
+
+  Future<List<District>> _loadDistricts() async {
+    final response = await _dio.get(_districtUrl);
+    final data = response.data as List<dynamic>;
+    return data
+        .map((e) =>
+            District.fromJson(Map<String, dynamic>.from(e as Map<String, dynamic>)))
+        .toList();
+  }
+
+  Future<List<SubDistrict>> _loadSubDistricts() async {
+    final response = await _dio.get(_subDistrictUrl);
+    final data = response.data as List<dynamic>;
+    return data
+        .map((e) => SubDistrict.fromJson(
+            Map<String, dynamic>.from(e as Map<String, dynamic>)))
+        .toList();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce address and Thai administrative area models plus a service that loads provinces, districts, and subdistricts
- refresh the profile and address management flows to stream Firestore data, surface defaults, and guide users through a responsive form
- enhance the add-address experience with map selection, geocoding fallbacks, hierarchical dropdowns, and improved map search/location permission handling

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f4888ff25083299fde93f8cdb92bd2