### PR TITLE
Refine address form layout and update Thai address source

### DIFF
--- a/lib/pages/addNewAddress.dart
+++ b/lib/pages/addNewAddress.dart
@@ -291,103 +291,148 @@ class _AddNewAddressState extends State<AddNewAddress> {
   }
 
   Widget _buildProvinceDropdown() {
-    return DropdownButtonFormField<Province>(
-      value: _selectedProvince,
-      isExpanded: true,
-      decoration: _dropdownDecoration('จังหวัด'),
-      items: _provinces
-          .map(
-            (province) => DropdownMenuItem<Province>(
-              value: province,
-              child: Text(province.nameTh, overflow: TextOverflow.ellipsis),
-            ),
-          )
-          .toList(),
-      onChanged: (value) {
-        if (value == null) return;
-        _onProvinceChanged(value);
-      },
-      validator: (_) {
-        if (_selectedProvince == null) {
-          return 'กรุณาเลือกจังหวัด';
-        }
-        return null;
-      },
+    return _buildLabeledField(
+      label: 'จังหวัด',
+      child: DropdownButtonFormField<Province>(
+        value: _selectedProvince,
+        isExpanded: true,
+        decoration: _fieldDecoration(),
+        hint: const Text(
+          'เลือกจังหวัด',
+          style: TextStyle(color: Color(0xFF848484)),
+        ),
+        items: _provinces
+            .map(
+              (province) => DropdownMenuItem<Province>(
+                value: province,
+                child:
+                    Text(province.nameTh, overflow: TextOverflow.ellipsis),
+              ),
+            )
+            .toList(),
+        onChanged: (value) {
+          if (value == null) return;
+          _onProvinceChanged(value);
+        },
+        validator: (_) {
+          if (_selectedProvince == null) {
+            return 'กรุณาเลือกจังหวัด';
+          }
+          return null;
+        },
+      ),
     );
   }
 
   Widget _buildDistrictDropdown() {
-    return DropdownButtonFormField<District>(
-      value: _selectedDistrict,
-      isExpanded: true,
-      decoration: _dropdownDecoration('อำเภอ'),
-      items: _districts
-          .map(
-            (district) => DropdownMenuItem<District>(
-              value: district,
-              child: Text(district.nameTh, overflow: TextOverflow.ellipsis),
-            ),
-          )
-          .toList(),
-      onChanged: _districts.isEmpty
-          ? null
-          : (value) {
-              if (value == null) return;
-              _onDistrictChanged(value);
-            },
-      validator: (_) {
-        if (_selectedProvince == null) {
-          return 'กรุณาเลือกจังหวัดก่อน';
-        }
-        if (_selectedDistrict == null) {
-          return _districtError ?? 'กรุณาเลือกอำเภอ';
-        }
-        return null;
-      },
-      disabledHint: _loadingDistricts
-          ? const Text('กำลังโหลดอำเภอ...', style: TextStyle(color: Colors.white54))
-          : const Text('เลือกจังหวัดก่อน', style: TextStyle(color: Colors.white54)),
+    return _buildLabeledField(
+      label: 'อำเภอ',
+      child: DropdownButtonFormField<District>(
+        value: _selectedDistrict,
+        isExpanded: true,
+        decoration: _fieldDecoration(),
+        hint: const Text(
+          'เลือกอำเภอ',
+          style: TextStyle(color: Color(0xFF848484)),
+        ),
+        items: _districts
+            .map(
+              (district) => DropdownMenuItem<District>(
+                value: district,
+                child:
+                    Text(district.nameTh, overflow: TextOverflow.ellipsis),
+              ),
+            )
+            .toList(),
+        onChanged: _districts.isEmpty
+            ? null
+            : (value) {
+                if (value == null) return;
+                _onDistrictChanged(value);
+              },
+        validator: (_) {
+          if (_selectedProvince == null) {
+            return 'กรุณาเลือกจังหวัดก่อน';
+          }
+          if (_selectedDistrict == null) {
+            return _districtError ?? 'กรุณาเลือกอำเภอ';
+          }
+          return null;
+        },
+        disabledHint: _loadingDistricts
+            ? const Text('กำลังโหลดอำเภอ...',
+                style: TextStyle(color: Colors.white54))
+            : const Text('เลือกจังหวัดก่อน',
+                style: TextStyle(color: Colors.white54)),
+      ),
     );
   }
 
   Widget _buildSubDistrictDropdown() {
-    return DropdownButtonFormField<SubDistrict>(
-      value: _selectedSubDistrict,
-      isExpanded: true,
-      decoration: _dropdownDecoration('ตำบล'),
-      items: _subDistricts
-          .map(
-            (subDistrict) => DropdownMenuItem<SubDistrict>(
-              value: subDistrict,
-              child: Text(subDistrict.nameTh, overflow: TextOverflow.ellipsis),
-            ),
-          )
-          .toList(),
-      onChanged: _subDistricts.isEmpty
-          ? null
-          : (value) {
-              if (value == null) return;
-              _onSubDistrictChanged(value);
-            },
-      validator: (_) {
-        if (_selectedDistrict == null) {
-          return 'กรุณาเลือกอำเภอก่อน';
-        }
-        if (_selectedSubDistrict == null) {
-          return _subDistrictError ?? 'กรุณาเลือกตำบล';
-        }
-        return null;
-      },
-      disabledHint: _loadingSubDistricts
-          ? const Text('กำลังโหลดตำบล...', style: TextStyle(color: Colors.white54))
-          : const Text('เลือกอำเภอก่อน', style: TextStyle(color: Colors.white54)),
+    return _buildLabeledField(
+      label: 'ตำบล',
+      child: DropdownButtonFormField<SubDistrict>(
+        value: _selectedSubDistrict,
+        isExpanded: true,
+        decoration: _fieldDecoration(),
+        hint: const Text(
+          'เลือกตำบล',
+          style: TextStyle(color: Color(0xFF848484)),
+        ),
+        items: _subDistricts
+            .map(
+              (subDistrict) => DropdownMenuItem<SubDistrict>(
+                value: subDistrict,
+                child: Text(subDistrict.nameTh,
+                    overflow: TextOverflow.ellipsis),
+              ),
+            )
+            .toList(),
+        onChanged: _subDistricts.isEmpty
+            ? null
+            : (value) {
+                if (value == null) return;
+                _onSubDistrictChanged(value);
+              },
+        validator: (_) {
+          if (_selectedDistrict == null) {
+            return 'กรุณาเลือกอำเภอก่อน';
+          }
+          if (_selectedSubDistrict == null) {
+            return _subDistrictError ?? 'กรุณาเลือกตำบล';
+          }
+          return null;
+        },
+        disabledHint: _loadingSubDistricts
+            ? const Text('กำลังโหลดตำบล...',
+                style: TextStyle(color: Colors.white54))
+            : const Text('เลือกอำเภอก่อน',
+                style: TextStyle(color: Colors.white54)),
+      ),
     );
   }
 
-  InputDecoration _dropdownDecoration(String label) {
+  Widget _buildLabeledField({
+    required String label,
+    required Widget child,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(color: Color(0xFFBBB9B9), fontSize: 16),
+        ),
+        const SizedBox(height: 6),
+        child,
+      ],
+    );
+  }
+
+  InputDecoration _fieldDecoration({String? hintText}) {
     return InputDecoration(
-      labelText: label,
-      labelStyle: const TextStyle(color: Color(0xFFBBB9B9), fontSize: 16),
+      hintText: hintText,
+      hintStyle: const TextStyle(color: Color(0xFF848484), fontSize: 14),
       filled: true,
       fillColor: Colors.white,
       border: OutlineInputBorder(
@@ -410,38 +455,18 @@ class _AddNewAddressState extends State<AddNewAddress> {
     TextInputType? keyboardType,
     int maxLines = 1,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: const TextStyle(color: Color(0xFFBBB9B9), fontSize: 16),
+    return _buildLabeledField(
+      label: label,
+      child: TextFormField(
+        controller: controller,
+        validator: validator,
+        keyboardType: keyboardType,
+        maxLines: maxLines,
+        style: const TextStyle(color: Colors.black87),
+        decoration: _fieldDecoration(hintText: hint).copyWith(
+          alignLabelWithHint: maxLines > 1,
         ),
-        const SizedBox(height: 6),
-        TextFormField(
-          controller: controller,
-          validator: validator,
-          keyboardType: keyboardType,
-          maxLines: maxLines,
-          style: const TextStyle(color: Colors.black87),
-          decoration: InputDecoration(
-            hintText: hint,
-            hintStyle: const TextStyle(color: Color(0xFF848484), fontSize: 14),
-            filled: true,
-            fillColor: Colors.white,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(8),
-              borderSide: const BorderSide(color: Color(0xFFC7C0C0), width: 1.2),
-            ),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(8),
-              borderSide: const BorderSide(color: Color(0xFFC7C0C0), width: 1.2),
-            ),
-            contentPadding:
-                const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
-          ),
-        ),
-      ],
+      ),
     );
   }
 

--- a/lib/services/thai_address_service.dart
+++ b/lib/services/thai_address_service.dart
@@ -15,18 +15,18 @@ class ThaiAddressService {
   List<SubDistrict>? _cachedSubDistricts;
 
   static const _provinceUrl =
-      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_province.json';
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/main/api_province.json';
   static const _districtUrl =
-      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_amphure.json';
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/main/api_amphure.json';
   static const _subDistrictUrl =
-      'https://raw.githubusercontent.com/kongvut/thai-province-data/master/api_tambon.json';
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/main/api_tambon.json';
 
   Future<List<Province>> getProvinces() async {
     if (_cachedProvinces != null) {
       return _cachedProvinces!;
     }
     final response = await _dio.get(_provinceUrl);
-    final data = response.data as List<dynamic>;
+    final data = _validateResponseBody(response);
     _cachedProvinces = data
         .map((e) =>
             Province.fromJson(Map<String, dynamic>.from(e as Map<String, dynamic>)))
@@ -53,7 +53,7 @@ class ThaiAddressService {
 
   Future<List<District>> _loadDistricts() async {
     final response = await _dio.get(_districtUrl);
-    final data = response.data as List<dynamic>;
+    final data = _validateResponseBody(response);
     return data
         .map((e) =>
             District.fromJson(Map<String, dynamic>.from(e as Map<String, dynamic>)))
@@ -62,10 +62,21 @@ class ThaiAddressService {
 
   Future<List<SubDistrict>> _loadSubDistricts() async {
     final response = await _dio.get(_subDistrictUrl);
-    final data = response.data as List<dynamic>;
+    final data = _validateResponseBody(response);
     return data
         .map((e) => SubDistrict.fromJson(
             Map<String, dynamic>.from(e as Map<String, dynamic>)))
         .toList();
+  }
+
+  List<dynamic> _validateResponseBody(Response<dynamic> response) {
+    if (response.data is! List) {
+      throw DioException(
+        requestOptions: response.requestOptions,
+        response: response,
+        error: 'รูปแบบข้อมูลจังหวัด/อำเภอ/ตำบลไม่ถูกต้อง',
+      );
+    }
+    return response.data as List<dynamic>;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the province, district, and sub-district selectors to use consistent labeled fields that match the address form design
- reuse the same decoration helper for text inputs so all address fields share spacing and colors
- update Thai address service URLs to the repository's main branch and validate response formats to avoid 404s

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f498babe3883298a32f65921cf86ed