### PR TITLE
Update district and subdistrict dropdown hint text

### DIFF
--- a/lib/pages/addNewAddress.dart
+++ b/lib/pages/addNewAddress.dart
@@ -296,7 +296,7 @@ class _AddNewAddressState extends State<AddNewAddress> {
       child: DropdownButtonFormField<Province>(
         value: _selectedProvince,
         isExpanded: true,
-        decoration: _fieldDecoration(),
+        decoration: _fieldDecoration(hintText: 'เลือกจังหวัด'),
         hint: const Text(
           'เลือกจังหวัด',
           style: TextStyle(color: Color(0xFF848484)),
@@ -330,7 +330,7 @@ class _AddNewAddressState extends State<AddNewAddress> {
       child: DropdownButtonFormField<District>(
         value: _selectedDistrict,
         isExpanded: true,
-        decoration: _fieldDecoration(),
+        decoration: _fieldDecoration(hintText: 'เลือกอำเภอ'),
         hint: const Text(
           'เลือกอำเภอ',
           style: TextStyle(color: Color(0xFF848484)),
@@ -374,7 +374,7 @@ class _AddNewAddressState extends State<AddNewAddress> {
       child: DropdownButtonFormField<SubDistrict>(
         value: _selectedSubDistrict,
         isExpanded: true,
-        decoration: _fieldDecoration(),
+        decoration: _fieldDecoration(hintText: 'เลือกตำบล'),
         hint: const Text(
           'เลือกตำบล',
           style: TextStyle(color: Color(0xFF848484)),


### PR DESCRIPTION
## Summary
- ensure the province, district, and subdistrict dropdowns use matching hint text decorations
- add explicit hint text for the district and subdistrict dropdown fields so the placeholders read as expected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f49c3600888329b15f2f8efdac7b71