### PR TITLE
Update Thai address service to new dataset

### DIFF
--- a/lib/models/thai_address.dart
+++ b/lib/models/thai_address.dart
@@ -11,7 +11,7 @@ class Province {
 
   factory Province.fromJson(Map<String, dynamic> json) {
     return Province(
-      id: (json['id'] as num).toInt(),
+      id: _parseId(json['id']),
       nameTh: json['name_th'] as String,
       nameEn: json['name_en'] as String,
     );
@@ -32,11 +32,16 @@ class District {
   final int provinceId;
 
   factory District.fromJson(Map<String, dynamic> json) {
+    final provinceIdValue =
+        json['province_id'] ?? json['provinceId'] ?? json['province_code'];
+    if (provinceIdValue == null) {
+      throw const FormatException('Missing province id in district payload');
+    }
     return District(
-      id: (json['id'] as num).toInt(),
+      id: _parseId(json['id']),
       nameTh: json['name_th'] as String,
       nameEn: json['name_en'] as String,
-      provinceId: (json['province_id'] as num).toInt(),
+      provinceId: _parseId(provinceIdValue),
     );
   }
 }
@@ -57,12 +62,30 @@ class SubDistrict {
   final int districtId;
 
   factory SubDistrict.fromJson(Map<String, dynamic> json) {
+    final districtIdValue = json['amphure_id'] ??
+        json['district_id'] ??
+        json['districtId'] ??
+        json['amphure_code'] ??
+        json['district_code'];
+    if (districtIdValue == null) {
+      throw const FormatException('Missing district id in sub-district payload');
+    }
     return SubDistrict(
-      id: (json['id'] as num).toInt(),
+      id: _parseId(json['id']),
       nameTh: json['name_th'] as String,
       nameEn: json['name_en'] as String,
-      zipCode: json['zip_code'] as String,
-      districtId: (json['amphure_id'] as num).toInt(),
+      zipCode: json['zip_code'].toString(),
+      districtId: _parseId(districtIdValue),
     );
   }
+}
+
+int _parseId(dynamic value) {
+  if (value is num) {
+    return value.toInt();
+  }
+  if (value is String) {
+    return int.parse(value);
+  }
+  throw FormatException('Invalid identifier value: $value');
 }

--- a/lib/services/thai_address_service.dart
+++ b/lib/services/thai_address_service.dart
@@ -15,11 +15,11 @@ class ThaiAddressService {
   List<SubDistrict>? _cachedSubDistricts;
 
   static const _provinceUrl =
-      'https://raw.githubusercontent.com/kongvut/thai-province-data/main/api_province.json';
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/refs/heads/master/api/latest/province.json';
   static const _districtUrl =
-      'https://raw.githubusercontent.com/kongvut/thai-province-data/main/api_amphure.json';
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/refs/heads/master/api/latest/district.json';
   static const _subDistrictUrl =
-      'https://raw.githubusercontent.com/kongvut/thai-province-data/main/api_tambon.json';
+      'https://raw.githubusercontent.com/kongvut/thai-province-data/refs/heads/master/api/latest/sub_district.json';
 
   Future<List<Province>> getProvinces() async {
     if (_cachedProvinces != null) {
@@ -70,13 +70,23 @@ class ThaiAddressService {
   }
 
   List<dynamic> _validateResponseBody(Response<dynamic> response) {
-    if (response.data is! List) {
-      throw DioException(
-        requestOptions: response.requestOptions,
-        response: response,
-        error: 'รูปแบบข้อมูลจังหวัด/อำเภอ/ตำบลไม่ถูกต้อง',
-      );
+    final dynamic body = response.data;
+
+    if (body is List) {
+      return body;
     }
-    return response.data as List<dynamic>;
+
+    if (body is Map<String, dynamic>) {
+      final dynamic data = body['data'];
+      if (data is List) {
+        return data;
+      }
+    }
+
+    throw DioException(
+      requestOptions: response.requestOptions,
+      response: response,
+      error: 'รูปแบบข้อมูลจังหวัด/อำเภอ/ตำบลไม่ถูกต้อง',
+    );
   }
 }


### PR DESCRIPTION
## Summary
- switch Thai address API client to the latest province, district, and sub-district datasets
- harden JSON parsing to accept numeric identifiers encoded as strings and support alternative key names from the new payloads
- improve response validation to handle either a raw list or list-wrapped payloads

## Testing
- flutter analyze *(fails: Flutter SDK not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f49cb2b7d88329a77eb1361aa25cc4