### PR TITLE
Handle plain text Thai address responses

### DIFF
--- a/lib/services/thai_address_service.dart
+++ b/lib/services/thai_address_service.dart
@@ -1,5 +1,7 @@
-import 'package:dio/dio.dart';
+import 'dart:convert';
+
 import 'package:delivery_app/models/thai_address.dart';
+import 'package:dio/dio.dart';
 
 class ThaiAddressService {
   ThaiAddressService({
@@ -80,16 +82,38 @@ class ThaiAddressService {
   }
 
   List<dynamic> _validateResponseBody(Response<dynamic> response) {
-    final dynamic body = response.data;
+    dynamic body = response.data;
+
+    if (body is String) {
+      if (body.trim().isEmpty) {
+        throw DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          error: 'ไม่พบข้อมูลจังหวัด/อำเภอ/ตำบล',
+        );
+      }
+      try {
+        body = jsonDecode(body);
+      } on FormatException catch (error) {
+        throw DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          error:
+              'รูปแบบข้อมูลจังหวัด/อำเภอ/ตำบลไม่ถูกต้อง: ${error.message}',
+        );
+      }
+    }
 
     if (body is List) {
       return body;
     }
 
     if (body is Map<String, dynamic>) {
-      final dynamic data = body['data'];
-      if (data is List) {
-        return data;
+      for (final key in const ['data', 'results', 'items']) {
+        final dynamic data = body[key];
+        if (data is List) {
+          return data;
+        }
       }
     }
 

--- a/test/services/thai_address_service_test.dart
+++ b/test/services/thai_address_service_test.dart
@@ -154,6 +154,28 @@ void main() {
         throwsA(isA<DioException>()),
       );
     });
+
+    test('parses JSON payload when response body is plain text', () async {
+      final adapter = _MockHttpClientAdapter({
+        Uri.parse(provinceUrl): _RawResponse(
+          '[{"id":1,"name_th":"กรุงเทพมหานคร","name_en":"Bangkok"}]',
+          headers: {Headers.contentTypeHeader: ['text/plain']},
+        ),
+      });
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = ThaiAddressService(
+        dio: dio,
+        provinceUrl: provinceUrl,
+        districtUrl: districtUrl,
+        subDistrictUrl: subDistrictUrl,
+      );
+
+      final provinces = await service.getProvinces();
+
+      expect(provinces, hasLength(1));
+      expect(provinces.first.nameEn, 'Bangkok');
+      expect(adapter.callCounts[Uri.parse(provinceUrl)], 1);
+    });
   });
 }
 
@@ -178,13 +200,30 @@ class _MockHttpClientAdapter implements HttpClientAdapter {
       throw StateError('No mock response registered for $uri');
     }
 
-    final body = jsonEncode(_responses[uri]);
+    final response = _responses[uri];
+    late final String body;
+    Map<String, List<String>> headers = {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    };
+    if (response is _RawResponse) {
+      body = response.body;
+      headers = response.headers;
+    } else {
+      body = jsonEncode(response);
+    }
     return ResponseBody.fromString(
       body,
       200,
-      headers: {
-        Headers.contentTypeHeader: [Headers.jsonContentType],
-      },
+      headers: headers,
     );
   }
+}
+
+class _RawResponse {
+  _RawResponse(this.body, {Map<String, List<String>>? headers})
+      : headers = headers ??
+            {Headers.contentTypeHeader: [Headers.jsonContentType]};
+
+  final String body;
+  final Map<String, List<String>> headers;
 }


### PR DESCRIPTION
## Summary
- teach `ThaiAddressService` to decode JSON responses that arrive as plain text and improve validation fallbacks
- extend the service tests with coverage for plain-text payloads and allow the mock adapter to serve raw responses

## Testing
- not run (Flutter/Dart SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f4a6f1b08483298fb3cc4291ac5185