### PR TITLE
Handle Firestore query error on user addresses

### DIFF
--- a/lib/pages/useraddress.dart
+++ b/lib/pages/useraddress.dart
@@ -31,8 +31,6 @@ class _UserAddressPageState extends State<UserAddressPage> {
     return FirebaseFirestore.instance
         .collection('addresses')
         .where('uid', isEqualTo: uid)
-        .orderBy('is_default')
-        .orderBy('create_at', descending: true)
         .snapshots();
   }
 
@@ -95,7 +93,28 @@ class _UserAddressPageState extends State<UserAddressPage> {
                   }
 
                   final addresses =
-                      docs.map(Address.fromFirestore).toList(growable: false);
+                      docs.map(Address.fromFirestore).toList(growable: true)
+                        ..sort((a, b) {
+                          final defaultCompare = a.isDefault.compareTo(b.isDefault);
+                          if (defaultCompare != 0) {
+                            return defaultCompare;
+                          }
+
+                          final aCreated = a.createdAt?.toDate();
+                          final bCreated = b.createdAt?.toDate();
+
+                          if (aCreated == null && bCreated == null) {
+                            return 0;
+                          }
+                          if (aCreated == null) {
+                            return 1;
+                          }
+                          if (bCreated == null) {
+                            return -1;
+                          }
+
+                          return bCreated.compareTo(aCreated);
+                        });
 
                   return ListView.separated(
                     padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),


### PR DESCRIPTION
## Summary
- adjust the user address stream to avoid the Firestore composite index error by removing chained orderBy calls
- sort addresses locally so default entries stay on top and newer entries follow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4c6930d4483298a30267760511230