### PR TITLE
Fix Firestore stream error on user address page

### DIFF
--- a/lib/pages/useraddress.dart
+++ b/lib/pages/useraddress.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:bootstrap_icons/bootstrap_icons.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:delivery_app/models/address.dart';
@@ -14,7 +16,7 @@ class UserAddressPage extends StatefulWidget {
 }
 
 class _UserAddressPageState extends State<UserAddressPage> {
-  late final Stream<QuerySnapshot<Map<String, dynamic>>> _addressStream;
+  late Stream<List<Address>> _addressStream;
 
   @override
   void initState() {
@@ -22,16 +24,51 @@ class _UserAddressPageState extends State<UserAddressPage> {
     _addressStream = _buildAddressStream();
   }
 
-  Stream<QuerySnapshot<Map<String, dynamic>>> _buildAddressStream() {
+  @override
+  void didUpdateWidget(covariant UserAddressPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.uid != widget.uid) {
+      _addressStream = _buildAddressStream();
+    }
+  }
+
+  Stream<List<Address>> _buildAddressStream() {
     final uid = widget.uid;
     if (uid == null || uid.isEmpty) {
-      return Stream<QuerySnapshot<Map<String, dynamic>>>.empty();
+      return const Stream<List<Address>>.value(<Address>[]);
     }
 
     return FirebaseFirestore.instance
         .collection('addresses')
         .where('uid', isEqualTo: uid)
-        .snapshots();
+        .snapshots()
+        .map((snapshot) {
+      final addresses =
+          snapshot.docs.map(Address.fromFirestore).toList(growable: true)
+            ..sort((a, b) {
+              final defaultCompare = a.isDefault.compareTo(b.isDefault);
+              if (defaultCompare != 0) {
+                return defaultCompare;
+              }
+
+              final aCreated = a.createdAt?.toDate();
+              final bCreated = b.createdAt?.toDate();
+
+              if (aCreated == null && bCreated == null) {
+                return 0;
+              }
+              if (aCreated == null) {
+                return 1;
+              }
+              if (bCreated == null) {
+                return -1;
+              }
+
+              return bCreated.compareTo(aCreated);
+            });
+
+      return addresses;
+    });
   }
 
   @override
@@ -64,18 +101,26 @@ class _UserAddressPageState extends State<UserAddressPage> {
         child: Column(
           children: [
             Expanded(
-              child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+              child: StreamBuilder<List<Address>>(
                 stream: _addressStream,
                 builder: (context, snapshot) {
-                  if (widget.uid == null || widget.uid!.isEmpty) {
-                    return _buildEmptyState(context);
-                  }
-
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const Center(child: CircularProgressIndicator());
                   }
 
                   if (snapshot.hasError) {
+                    log(
+                      'เกิดข้อผิดพลาดในการโหลดที่อยู่',
+                      error: snapshot.error,
+                      stackTrace: snapshot.stackTrace,
+                    );
+
+                    final fallbackAddresses = snapshot.data;
+                    if (fallbackAddresses != null &&
+                        fallbackAddresses.isNotEmpty) {
+                      return _AddressListView(addresses: fallbackAddresses);
+                    }
+
                     return Center(
                       child: Text(
                         'เกิดข้อผิดพลาดในการโหลดข้อมูล',
@@ -87,44 +132,13 @@ class _UserAddressPageState extends State<UserAddressPage> {
                     );
                   }
 
-                  final docs = snapshot.data?.docs ?? [];
-                  if (docs.isEmpty) {
+                  final addresses = snapshot.data ?? const <Address>[];
+
+                  if (addresses.isEmpty) {
                     return _buildEmptyState(context);
                   }
 
-                  final addresses =
-                      docs.map(Address.fromFirestore).toList(growable: true)
-                        ..sort((a, b) {
-                          final defaultCompare = a.isDefault.compareTo(b.isDefault);
-                          if (defaultCompare != 0) {
-                            return defaultCompare;
-                          }
-
-                          final aCreated = a.createdAt?.toDate();
-                          final bCreated = b.createdAt?.toDate();
-
-                          if (aCreated == null && bCreated == null) {
-                            return 0;
-                          }
-                          if (aCreated == null) {
-                            return 1;
-                          }
-                          if (bCreated == null) {
-                            return -1;
-                          }
-
-                          return bCreated.compareTo(aCreated);
-                        });
-
-                  return ListView.separated(
-                    padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
-                    itemCount: addresses.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 12),
-                    itemBuilder: (context, index) {
-                      final address = addresses[index];
-                      return _AddressTile(address: address);
-                    },
-                  );
+                  return _AddressListView(addresses: addresses);
                 },
               ),
             ),
@@ -190,6 +204,25 @@ class _UserAddressPageState extends State<UserAddressPage> {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _AddressListView extends StatelessWidget {
+  const _AddressListView({required this.addresses});
+
+  final List<Address> addresses;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+      itemCount: addresses.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final address = addresses[index];
+        return _AddressTile(address: address);
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the user address stream as a typed list and keep sorting client-side
- add error logging and reuse cached data when Firestore emits recoverable errors
- refresh the stream when the UID changes and extract a dedicated list view widget

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4c8a4176c8329a53faa25855301c6