### PR TITLE
Add Firestore ordering for user address stream

### DIFF
--- a/lib/pages/useraddress.dart
+++ b/lib/pages/useraddress.dart
@@ -31,6 +31,8 @@ class _UserAddressPageState extends State<UserAddressPage> {
     return FirebaseFirestore.instance
         .collection('addresses')
         .where('uid', isEqualTo: uid)
+        .orderBy('is_default', descending: true)
+        .orderBy('create_at', descending: true)
         .snapshots();
   }
 


### PR DESCRIPTION
## Summary
- ensure the user address stream orders by default flag and creation timestamp so it uses the configured composite index

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4d4b4f1508329b59947e238a631f7