### PR TITLE
Fix EditAddressPage constructor const usage

### DIFF
--- a/lib/pages/editAddress.dart
+++ b/lib/pages/editAddress.dart
@@ -2,7 +2,7 @@ import 'package:delivery_app/models/address.dart';
 import 'package:delivery_app/pages/addNewAddress.dart';
 
 class EditAddressPage extends AddressFormPage {
-  const EditAddressPage({super.key, required Address address})
+  EditAddressPage({super.key, required Address address})
       : super(
           uid: address.uid,
           initialAddress: address,


### PR DESCRIPTION
## Summary
- make the EditAddressPage constructor non-const so runtime address data can be forwarded to the base class

## Testing
- flutter analyze *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4ef037b848329927ed2bdfd4995bd