### PR TITLE
Ensure logout success message is displayed before redirect

### DIFF
--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -238,10 +238,11 @@ class _ProfilePageState extends State<ProfilePage> {
       await showSuccessDialog(
         context,
         message: 'ออกจากระบบสำเร็จ',
+        onOk: () {
+          if (!mounted) return;
+          context.go('/');
+        },
       );
-
-      if (!mounted) return;
-      context.go('/');
     } catch (e) {
       if (!mounted) return;
       await showErrorDialog(


### PR DESCRIPTION
## Summary
- wait for the logout success notification to close before navigating away from the profile page

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5145b006c8329a26c17cada0e7f78