### PR TITLE
Improve map picker address autofill reliability

### DIFF
--- a/lib/pages/addNewAddress.dart
+++ b/lib/pages/addNewAddress.dart
@@ -679,13 +679,77 @@ class _AddressFormPageState extends State<AddressFormPage> {
       ]),
     );
 
-    await _selectProvinceByName(provinceName, fromAutoFill: true);
-    await _selectDistrictByName(districtName, fromAutoFill: true);
-    await _selectSubDistrictByName(subDistrictName);
+    var matchedProvince =
+        await _selectProvinceByName(provinceName, fromAutoFill: true);
+    var matchedDistrict =
+        await _selectDistrictByName(districtName, fromAutoFill: true);
+    var matchedSubDistrict = await _selectSubDistrictByName(subDistrictName);
 
-    final postalCode = _firstNonEmpty(components, const ['postcode', 'postal_code']);
+    final postalCode =
+        _firstNonEmpty(components, const ['postcode', 'postal_code']);
+    List<SubDistrict> postalMatches = <SubDistrict>[];
+    if (postalCode != null && postalCode.length == 5) {
+      postalMatches = await _thaiAddressService
+          .findSubDistrictsByPostalCode(postalCode);
+    }
+
+    if (postalMatches.isNotEmpty &&
+        (matchedProvince == null ||
+            matchedDistrict == null ||
+            matchedSubDistrict == null)) {
+      final fallbackSubDistrict = await _resolveSubDistrictFromPostalMatches(
+        postalMatches,
+        subDistrictName,
+        districtName,
+      );
+
+      if (fallbackSubDistrict != null) {
+        final fallbackDistrict = await _thaiAddressService
+            .getDistrictById(fallbackSubDistrict.districtId);
+        Province? fallbackProvince;
+        if (fallbackDistrict != null) {
+          fallbackProvince = await _thaiAddressService
+              .getProvinceById(fallbackDistrict.provinceId);
+        }
+
+        if (fallbackProvince != null) {
+          final provinceId = fallbackProvince.id;
+          final provinceInList =
+              _provinces.firstWhereOrNull((province) => province.id == provinceId);
+          if (provinceInList != null &&
+              (_selectedProvince?.id != provinceInList.id ||
+                  _districts.isEmpty)) {
+            await _onProvinceChanged(provinceInList, fromAutoFill: true);
+          }
+          matchedProvince ??= provinceInList;
+        }
+
+        if (fallbackDistrict != null) {
+          final districtId = fallbackDistrict.id;
+          final districtInList =
+              _districts.firstWhereOrNull((district) => district.id == districtId);
+          if (districtInList != null &&
+              (_selectedDistrict?.id != districtInList.id ||
+                  _subDistricts.isEmpty)) {
+            await _onDistrictChanged(districtInList, fromAutoFill: true);
+          }
+          matchedDistrict ??= districtInList;
+        }
+
+        final subDistrictInList = _subDistricts
+            .firstWhereOrNull((sub) => sub.id == fallbackSubDistrict.id);
+        if (subDistrictInList != null &&
+            (_selectedSubDistrict?.id != subDistrictInList.id)) {
+          _onSubDistrictChanged(subDistrictInList);
+        }
+        matchedSubDistrict ??= subDistrictInList;
+      }
+    }
+
     if (postalCode != null && postalCode.length == 5) {
       _postalCodeController.text = postalCode;
+    } else if (matchedSubDistrict != null) {
+      _postalCodeController.text = matchedSubDistrict.zipCode;
     }
 
     final houseNumber = _firstNonEmpty(components, const [
@@ -709,6 +773,58 @@ class _AddressFormPageState extends State<AddressFormPage> {
     }
 
     setState(() {});
+  }
+
+  Future<SubDistrict?> _resolveSubDistrictFromPostalMatches(
+    List<SubDistrict> candidates,
+    String? subDistrictName,
+    String? districtName,
+  ) async {
+    if (candidates.isEmpty) {
+      return null;
+    }
+
+    final normalizedSubDistrict = _normalize(subDistrictName);
+    if (normalizedSubDistrict.isNotEmpty) {
+      final match = candidates.firstWhereOrNull(
+        (candidate) =>
+            _normalizedStringsMatch(
+              normalizedSubDistrict,
+              _normalize(candidate.nameTh),
+            ) ||
+            _normalizedStringsMatch(
+              normalizedSubDistrict,
+              _normalize(candidate.nameEn),
+            ),
+      );
+      if (match != null) {
+        return match;
+      }
+    }
+
+    final normalizedDistrict = _normalize(districtName);
+    if (normalizedDistrict.isNotEmpty) {
+      for (final candidate in candidates) {
+        final district =
+            await _thaiAddressService.getDistrictById(candidate.districtId);
+        if (district == null) {
+          continue;
+        }
+        final matchesDistrict = _normalizedStringsMatch(
+              normalizedDistrict,
+              _normalize(district.nameTh),
+            ) ||
+            _normalizedStringsMatch(
+              normalizedDistrict,
+              _normalize(district.nameEn),
+            );
+        if (matchesDistrict) {
+          return candidate;
+        }
+      }
+    }
+
+    return candidates.first;
   }
 
   Future<Province?> _selectProvinceByName(String? name,

--- a/lib/services/thai_address_service.dart
+++ b/lib/services/thai_address_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:delivery_app/models/thai_address.dart';
 import 'package:dio/dio.dart';
 
@@ -61,6 +62,28 @@ class ThaiAddressService {
         .where((sub) => sub.districtId == districtId)
         .toList()
       ..sort((a, b) => a.nameTh.compareTo(b.nameTh));
+  }
+
+  Future<Province?> getProvinceById(int provinceId) async {
+    final provinces = await getProvinces();
+    return provinces.firstWhereOrNull((province) => province.id == provinceId);
+  }
+
+  Future<District?> getDistrictById(int districtId) async {
+    _cachedDistricts ??= await _loadDistricts();
+    return _cachedDistricts!.firstWhereOrNull((district) => district.id == districtId);
+  }
+
+  Future<List<SubDistrict>> findSubDistrictsByPostalCode(String postalCode) async {
+    final trimmed = postalCode.trim();
+    if (trimmed.isEmpty) {
+      return <SubDistrict>[];
+    }
+
+    _cachedSubDistricts ??= await _loadSubDistricts();
+    return _cachedSubDistricts!
+        .where((subDistrict) => subDistrict.zipCode == trimmed)
+        .toList();
   }
 
   Future<List<District>> _loadDistricts() async {


### PR DESCRIPTION
## Summary
- improve address autofill by selecting province, district, and sub-district using postal code fallbacks when map data lacks clean names
- expose ThaiAddressService helpers to resolve address components by identifier or postal code to support the new autofill logic

## Testing
- not run (Flutter SDK unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f53a835cd883299cc0d92deeac291f