### PR TITLE
Update delivery query to filter by sender

### DIFF
--- a/lib/pages/deliveryList.dart
+++ b/lib/pages/deliveryList.dart
@@ -28,7 +28,7 @@ class _DeliverylistPageState extends State<DeliverylistPage> {
 
     return FirebaseFirestore.instance
         .collection('delivery')
-        .where('receiver_uid', isEqualTo: currentUser.uid)
+        .where('sender_uid', isEqualTo: currentUser.uid)
         .orderBy('created_at', descending: true)
         .snapshots()
         .asyncMap((snapshot) async {


### PR DESCRIPTION
## Summary
- update the delivery list stream to filter by the authenticated sender UID instead of the receiver UID

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f55fbbabf0832983186b53df418f3a