### PR TITLE
Handle overflow in delivery tracking map markers

### DIFF
--- a/lib/pages/trackDelivery.dart
+++ b/lib/pages/trackDelivery.dart
@@ -346,8 +346,8 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
 
     return Marker(
       point: delivery.position,
-      width: 96,
-      height: 96,
+      width: 140,
+      height: 120,
       builder: (context) => GestureDetector(
         onTap: () => _onFocusRequest(delivery),
         child: Column(
@@ -355,6 +355,7 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
           children: [
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              constraints: const BoxConstraints(maxWidth: 120),
               decoration: BoxDecoration(
                 color: Colors.black.withOpacity(0.65),
                 borderRadius: BorderRadius.circular(14),
@@ -366,6 +367,10 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
                   fontSize: 11,
                   fontWeight: FontWeight.w600,
                 ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                softWrap: false,
+                textAlign: TextAlign.center,
               ),
             ),
             const SizedBox(height: 6),


### PR DESCRIPTION
## Summary
- widen the delivery tracking marker builder to provide more room for the label
- constrain the label width and truncate long text so it no longer overflows the marker

## Testing
- Not run (Flutter SDK not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6afc3b6e48329a60e3f4d6d4cf976