### PR TITLE
Add red highlight to map marker and location icons

### DIFF
--- a/lib/pages/trackDelivery.dart
+++ b/lib/pages/trackDelivery.dart
@@ -381,9 +381,9 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
                 border: Border.all(color: Colors.white, width: 2),
                 boxShadow: const [
                   BoxShadow(
-                    color: Colors.black38,
-                    blurRadius: 8,
-                    offset: Offset(0, 4),
+                    color: Color(0x66FF3B30),
+                    blurRadius: 10,
+                    offset: Offset(0, 6),
                   ),
                 ],
               ),
@@ -633,6 +633,13 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
           decoration: BoxDecoration(
             color: const Color(0x2216A34A),
             borderRadius: BorderRadius.circular(14),
+            boxShadow: const [
+              BoxShadow(
+                color: Color(0x55FF3B30),
+                blurRadius: 12,
+                offset: Offset(0, 8),
+              ),
+            ],
           ),
           child: Icon(
             icon,


### PR DESCRIPTION
## Summary
- add a red shadow glow beneath each delivery marker on the tracking map
- give the sender/receiver location icons a matching red shadow to emphasize building markers

## Testing
- not run (commands unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6b0d3d8a48329ab37507bc2824a33