### PR TITLE
Fix flutter_map marker widget configuration

### DIFF
--- a/lib/pages/trackDelivery.dart
+++ b/lib/pages/trackDelivery.dart
@@ -346,9 +346,8 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
 
     return Marker(
       point: delivery.position,
-      width: 140,
-      height: 120,
-      builder: (context) => GestureDetector(
+      alignment: Alignment.bottomCenter,
+      child: GestureDetector(
         onTap: () => _onFocusRequest(delivery),
         child: Column(
           mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- replace the invalid `builder` parameter with `child` on the flutter_map `Marker`
- remove the fixed marker size and align the widget to the bottom center for proper positioning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f753d07c4c832998dd90db4e3b97ac