### PR TITLE
Update OSM tile layer configuration

### DIFF
--- a/lib/pages/trackDelivery.dart
+++ b/lib/pages/trackDelivery.dart
@@ -307,8 +307,7 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
               children: [
                 TileLayer(
                   urlTemplate:
-                      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  subdomains: const ['a', 'b', 'c'],
+                      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'com.delivery.app',
                 ),
                 MarkerLayer(


### PR DESCRIPTION
## Summary
- update the flutter_map TileLayer to use the main OpenStreetMap tile server without deprecated subdomains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f759ef53788329b57797b922a7c889