### PR TITLE
Update firebase_database dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   firebase_storage: ^13.0.2
   firebase_auth: ^6.1.0
   cloud_firestore: ^6.0.2
-  firebase_database: ^11.0.3
+  firebase_database: ^11.1.3
   http: ^1.5.0
   awesome_snackbar_content: ^0.1.8
   google_maps_flutter: ^2.13.1


### PR DESCRIPTION
## Summary
- update the firebase_database dependency to ^11.1.3 to match firebase_core_platform_interface ^6 requirements

## Testing
- not run (Flutter SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f9f597aed48329ba8440f6df864ed5