### PR TITLE
Fix Firestore Query import conflict on track delivery page

### DIFF
--- a/lib/pages/trackDelivery.dart
+++ b/lib/pages/trackDelivery.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 import 'package:bootstrap_icons/bootstrap_icons.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_database/firebase_database.dart';
+import 'package:firebase_database/firebase_database.dart' as rtdb;
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -174,7 +174,7 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
   }
 
   Stream<Map<String, LatLng?>> _createRealtimeLocationStream() {
-    final ref = FirebaseDatabase.instance.ref('orders');
+    final ref = rtdb.FirebaseDatabase.instance.ref('orders');
     return ref.onValue.map((event) {
       final snapshot = event.snapshot;
       final locations = <String, LatLng?>{};


### PR DESCRIPTION
## Summary
- alias the Firebase Realtime Database import so it no longer exports Query into the global namespace
- adjust the realtime database reference to use the new alias when streaming rider locations

## Testing
- not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f9f7c747dc8329bb56fe6619f3cb39