### PR TITLE
Prevent race condition in track delivery stream controller

### DIFF
--- a/lib/pages/trackDelivery.dart
+++ b/lib/pages/trackDelivery.dart
@@ -68,6 +68,9 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
     _firestoreSubscription = _deliveriesStream.listen(
       _onDeliveriesUpdated,
       onError: (error, stackTrace) {
+        if (_locationStreamController.isClosed) {
+          return;
+        }
         _locationStreamController.addError(error, stackTrace);
       },
     );
@@ -222,6 +225,9 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
       final ref = rtdb.FirebaseDatabase.instance.ref('orders/$id');
       final subscription = ref.onValue.listen(
         (event) {
+          if (_locationStreamController.isClosed) {
+            return;
+          }
           final latLng = _extractRealtimeLocation(event.snapshot.value);
           if (latLng != null) {
             _currentLocations[id] = latLng;
@@ -232,12 +238,18 @@ class _TrackDeliveryPageState extends State<TrackDeliveryPage> {
               .add(Map<String, LatLng?>.from(_currentLocations));
         },
         onError: (error, stackTrace) {
+          if (_locationStreamController.isClosed) {
+            return;
+          }
           _locationStreamController.addError(error, stackTrace);
         },
       );
       _rtdbListeners[id] = subscription;
     }
 
+    if (_locationStreamController.isClosed) {
+      return;
+    }
     _locationStreamController.add(Map<String, LatLng?>.from(_currentLocations));
   }
 


### PR DESCRIPTION
## Summary
- add defensive checks before forwarding Firestore and RTDB stream events to the shared location controller
- skip pushing realtime updates when the controller has already been closed to prevent late events from crashing the page

## Testing
- `flutter analyze` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa00e901b88329887a9093c8ed99cf