### PR TITLE
Fix marker label overflow on assign detail map

### DIFF
--- a/lib/pages/assignDetail.dart
+++ b/lib/pages/assignDetail.dart
@@ -772,39 +772,41 @@ class _MapMarker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          padding: const EdgeInsets.all(6),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            shape: BoxShape.circle,
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withOpacity(0.25),
-                blurRadius: 8,
-              ),
-            ],
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 72),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.25),
+                  blurRadius: 8,
+                ),
+              ],
+            ),
+            child: Icon(
+              icon,
+              color: color,
+              size: 20,
+            ),
           ),
-          child: Icon(
-            icon,
-            color: color,
-            size: 20,
-          ),
-        ),
-        const SizedBox(height: 6),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: const Color(0xCC111827),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 160),
+          const SizedBox(height: 6),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: const Color(0xCC111827),
+              borderRadius: BorderRadius.circular(12),
+            ),
             child: Text(
               label,
               maxLines: 2,
+              softWrap: true,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,
               style: textTheme.bodySmall?.copyWith(
@@ -813,8 +815,8 @@ class _MapMarker extends StatelessWidget {
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- constrain the custom map marker widget to a compact width
- allow marker labels to wrap within the available width to avoid overflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb2f0b9ab4832987d9e28615fcef17